### PR TITLE
fix: scroll to current date at top of viewport on key dates page

### DIFF
--- a/src/components/keyDates/KeyDatesTimeline.tsx
+++ b/src/components/keyDates/KeyDatesTimeline.tsx
@@ -74,14 +74,20 @@ export function KeyDatesTimeline({ items }: KeyDatesTimelineProps) {
 		}
 
 		const prefersReducedMotion = window.matchMedia('(prefers-reduced-motion: reduce)').matches;
-		const frame = window.requestAnimationFrame(() => {
-			target.scrollIntoView({
-				behavior: prefersReducedMotion ? 'auto' : 'smooth',
-				block: 'center'
+		let frame2: number;
+		const frame1 = window.requestAnimationFrame(() => {
+			frame2 = window.requestAnimationFrame(() => {
+				target.scrollIntoView({
+					behavior: prefersReducedMotion ? 'auto' : 'smooth',
+					block: 'start'
+				});
 			});
 		});
 
-		return () => window.cancelAnimationFrame(frame);
+		return () => {
+			window.cancelAnimationFrame(frame1);
+			window.cancelAnimationFrame(frame2);
+		};
 	}, [closestIndex]);
 
 	return (

--- a/src/components/keyDates/KeyDatesTimeline.tsx
+++ b/src/components/keyDates/KeyDatesTimeline.tsx
@@ -74,7 +74,7 @@ export function KeyDatesTimeline({ items }: KeyDatesTimelineProps) {
 		}
 
 		const prefersReducedMotion = window.matchMedia('(prefers-reduced-motion: reduce)').matches;
-		let frame2: number;
+		let frame2 = 0;
 		const frame1 = window.requestAnimationFrame(() => {
 			frame2 = window.requestAnimationFrame(() => {
 				target.scrollIntoView({


### PR DESCRIPTION
- Change scrollIntoView block from 'center' to 'start' so the item
  lands at the top of the viewport (respecting scroll-mt-32/40 nav offset)
- Use double requestAnimationFrame to ensure scroll fires after Next.js
  hydration has fully settled layout

https://claude.ai/code/session_01LrnHVEqbHCW1Lwg5zMxkKX

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved scroll timing and positioning behavior on the key dates timeline for enhanced reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->