### PR TITLE
feat: refresh news page layout for readability

### DIFF
--- a/src/app/(site)/news/page.tsx
+++ b/src/app/(site)/news/page.tsx
@@ -9,10 +9,25 @@ export async function generateMetadata(): Promise<Metadata> {
 }
 
 export default async function NewsPage() {
-	const articles = await getNewsArticles({ limit: 20 });
+	const [articles, featuredPool] = await Promise.all([
+		getNewsArticles({ limit: 20 }),
+		getNewsArticles({ limit: 6, featured: true })
+	]);
 
 	const heroArticle = articles[0];
-	const gridArticles = articles.slice(1);
+	const primaryFeaturedArticles = featuredPool
+		.filter((article) => article._id !== heroArticle?._id)
+		.slice(0, 2);
+	const primaryFeaturedIds = new Set(primaryFeaturedArticles.map((article) => article._id));
+	const fallbackFeaturedArticles = articles
+		.slice(1)
+		.filter((article) => !article.featured && !primaryFeaturedIds.has(article._id))
+		.slice(0, Math.max(0, 2 - primaryFeaturedArticles.length));
+	const featuredArticles = [...primaryFeaturedArticles, ...fallbackFeaturedArticles];
+	const featuredIds = new Set(featuredArticles.map((article) => article._id));
+	const gridArticles = articles.slice(1).filter((article) => !featuredIds.has(article._id));
+	const featuredSectionTitle =
+		fallbackFeaturedArticles.length > 0 ? 'Top Updates' : 'Featured Updates';
 
 	return (
 		<PageContainer
@@ -32,20 +47,55 @@ export default async function NewsPage() {
 						/>
 					)}
 
+					{featuredArticles.length > 0 && (
+						<section className="mb-14">
+							<div className="mb-6 flex items-center gap-4">
+								<h2 className="text-2xl font-bold">{featuredSectionTitle}</h2>
+								<div className="bg-secondary h-0.5 flex-1 rounded-full" />
+							</div>
+							<div className="grid grid-cols-1 gap-6 xl:grid-cols-2">
+								{featuredArticles.map((article) => (
+									<div key={article._id} className="animate-fade-in-up">
+										<NewsCard
+											slug={article.slug}
+											title={article.title}
+											excerpt={article.excerpt}
+											publishedAt={article.publishedAt}
+											featuredImage={article.featuredImage}
+											featured
+											size="large"
+										/>
+									</div>
+								))}
+							</div>
+						</section>
+					)}
+
 					{gridArticles.length > 0 && (
-						<div className="grid grid-cols-1 gap-6 md:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4">
-							{gridArticles.map((article) => (
-								<NewsCard
-									key={article._id}
-									slug={article.slug}
-									title={article.title}
-									excerpt={article.excerpt}
-									publishedAt={article.publishedAt}
-									featuredImage={article.featuredImage}
-									featured={article.featured}
-								/>
-							))}
-						</div>
+						<section>
+							<div className="mb-6 flex items-center gap-4">
+								<h2 className="text-2xl font-bold">Latest News</h2>
+								<div className="bg-base-300 h-px flex-1" />
+							</div>
+							<div className="grid grid-cols-1 gap-6 md:grid-cols-2 xl:grid-cols-3">
+								{gridArticles.map((article, index) => (
+									<div
+										key={article._id}
+										className="animate-fade-in-up"
+										style={{ animationDelay: `${Math.min(index * 80, 500)}ms` }}
+									>
+										<NewsCard
+											slug={article.slug}
+											title={article.title}
+											excerpt={article.excerpt}
+											publishedAt={article.publishedAt}
+											featuredImage={article.featuredImage}
+											featured={article.featured}
+										/>
+									</div>
+								))}
+							</div>
+						</section>
 					)}
 				</>
 			)}

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -181,3 +181,19 @@ h6 {
 		transform: translateX(0);
 	}
 }
+
+@keyframes fadeInUp {
+	0% {
+		opacity: 0;
+		transform: translateY(16px);
+	}
+	100% {
+		opacity: 1;
+		transform: translateY(0);
+	}
+}
+
+.animate-fade-in-up {
+	opacity: 0;
+	animation: fadeInUp 0.6s ease-out forwards;
+}

--- a/src/components/news/NewsCard.tsx
+++ b/src/components/news/NewsCard.tsx
@@ -60,6 +60,13 @@ export function NewsCard({
 					/>
 				</figure>
 				<div className={`card-body relative ${isLarge ? 'p-7' : 'p-6'}`}>
+					{featured && (
+						<div className="mb-3">
+							<span className="bg-secondary text-secondary-content inline-flex items-center rounded-full px-2.5 py-1 text-[11px] font-semibold tracking-wide uppercase">
+								Featured
+							</span>
+						</div>
+					)}
 					<h3
 						className={`card-title line-clamp-2 font-bold text-balance ${
 							isLarge ? 'text-2xl leading-tight' : 'text-xl leading-snug'

--- a/src/components/news/NewsCard.tsx
+++ b/src/components/news/NewsCard.tsx
@@ -39,8 +39,8 @@ export function NewsCard({
 	return (
 		<Link href={`/news/${slug}`} className="group block h-full">
 			<div
-				className={`card bg-surface border-base-200/70 relative h-full overflow-hidden border shadow-md transition-all duration-300 group-hover:-translate-y-1 group-hover:shadow-xl ${
-					featured ? 'border-l-secondary border-l-4' : ''
+				className={`card bg-surface relative h-full overflow-hidden border shadow-md transition-all duration-300 group-hover:-translate-y-1 group-hover:shadow-xl ${
+					featured ? 'border-secondary/70 shadow-secondary/10' : 'border-base-200/70'
 				}`}
 			>
 				<figure

--- a/src/components/news/NewsCard.tsx
+++ b/src/components/news/NewsCard.tsx
@@ -13,6 +13,7 @@ interface NewsCardProps {
 		alt?: string;
 	};
 	featured?: boolean;
+	size?: 'default' | 'large';
 }
 
 export function NewsCard({
@@ -21,7 +22,8 @@ export function NewsCard({
 	excerpt,
 	publishedAt,
 	featuredImage,
-	featured = false
+	featured = false,
+	size = 'default'
 }: NewsCardProps) {
 	const publishedDate = new Date(publishedAt);
 	const relativeDate = formatDistanceToNow(publishedDate, { addSuffix: true });
@@ -32,38 +34,41 @@ export function NewsCard({
 		day: 'numeric'
 	});
 
+	const isLarge = size === 'large';
+
 	return (
-		<Link href={`/news/${slug}`} className="group">
+		<Link href={`/news/${slug}`} className="group block h-full">
 			<div
-				className={`card h-full overflow-hidden shadow-lg transition-all hover:shadow-xl ${
-					featured ? 'relative bg-linear-to-br from-blue-900 to-slate-950' : 'bg-surface'
+				className={`card bg-surface border-base-200/70 relative h-full overflow-hidden border shadow-md transition-all duration-300 group-hover:-translate-y-1 group-hover:shadow-xl ${
+					featured ? 'border-l-secondary border-l-4' : ''
 				}`}
 			>
-				{featured && (
-					<>
-						<div className="absolute -top-20 -right-20 h-72 w-72 rounded-full bg-blue-800/20 blur-3xl" />
-						<div className="absolute -bottom-20 -left-20 h-72 w-72 rounded-full bg-blue-950/30 blur-3xl" />
-					</>
-				)}
-				<figure className="relative aspect-video overflow-hidden">
+				<figure
+					className={`relative overflow-hidden ${isLarge ? 'aspect-[16/10]' : 'aspect-video'}`}
+				>
 					<Image
 						loader={sanityImageLoader}
 						src={featuredImage.url}
 						alt={featuredImage.alt || title}
 						fill
-						className="object-cover transition-transform duration-300 group-hover:scale-105"
-						sizes="(max-width: 768px) 100vw, (max-width: 1200px) 50vw, 33vw"
+						className="object-cover transition-transform duration-500 group-hover:scale-105"
+						sizes={
+							isLarge
+								? '(max-width: 768px) 100vw, (max-width: 1280px) 50vw, 40vw'
+								: '(max-width: 768px) 100vw, (max-width: 1280px) 50vw, 33vw'
+						}
 					/>
 				</figure>
-				<div className={`card-body relative p-6 ${featured ? 'text-white' : ''}`}>
-					{featured && (
-						<div className="bg-secondary mb-2 inline-block w-fit rounded px-3 py-1 text-xs font-bold tracking-wide text-white uppercase">
-							Featured
-						</div>
-					)}
-					<h3 className="card-title line-clamp-2 text-xl font-bold">{title}</h3>
+				<div className={`card-body relative ${isLarge ? 'p-7' : 'p-6'}`}>
+					<h3
+						className={`card-title line-clamp-2 font-bold text-balance ${
+							isLarge ? 'text-2xl leading-tight' : 'text-xl leading-snug'
+						}`}
+					>
+						{title}
+					</h3>
 					<p
-						className={`line-clamp-3 ${featured ? 'text-white/90' : 'text-(--color-base-content-secondary)'}`}
+						className={`text-(--color-base-content-secondary) ${isLarge ? 'line-clamp-4' : 'line-clamp-3'}`}
 					>
 						{excerpt}
 					</p>
@@ -71,7 +76,7 @@ export function NewsCard({
 						<time
 							dateTime={publishedDate.toISOString()}
 							title={fullDate}
-							className={`text-sm font-bold ${featured ? 'text-white/80' : 'text-(--color-base-content-secondary)'}`}
+							className="text-sm font-semibold text-(--color-base-content-secondary)"
 						>
 							{relativeDate}
 						</time>

--- a/src/components/news/NewsHero.tsx
+++ b/src/components/news/NewsHero.tsx
@@ -25,32 +25,37 @@ export function NewsHero({ slug, title, excerpt, publishedAt, featuredImage }: N
 	});
 
 	return (
-		<Link href={`/news/${slug}`} className="group mb-8 block md:mb-12">
-			<article className="bg-surface overflow-hidden rounded-lg shadow-lg transition-shadow hover:shadow-xl">
-				<div className="grid gap-0 md:grid-cols-5">
-					<figure className="relative aspect-video overflow-hidden md:col-span-2 md:aspect-auto md:h-full">
+		<Link href={`/news/${slug}`} className="group mb-12 block md:mb-14">
+			<article className="bg-surface border-base-200/70 overflow-hidden rounded-3xl border shadow-lg transition-all duration-300 hover:-translate-y-1 hover:shadow-2xl">
+				<div className="grid gap-0 lg:min-h-[34rem] lg:grid-cols-5">
+					<figure className="relative aspect-[16/10] overflow-hidden lg:col-span-3 lg:aspect-auto lg:h-full">
 						<Image
 							loader={sanityImageLoader}
 							src={featuredImage.url}
 							alt={featuredImage.alt || title}
 							fill
-							className="object-cover transition-transform duration-500 group-hover:scale-105"
-							sizes="(max-width: 768px) 100vw, (max-width: 1280px) 40vw, 512px"
+							className="object-cover transition-transform duration-700 group-hover:scale-105"
+							sizes="(max-width: 1024px) 100vw, 60vw"
 							priority
 						/>
+						<div className="pointer-events-none absolute inset-x-0 bottom-0 h-24 bg-linear-to-t from-black/35 to-transparent lg:hidden" />
 					</figure>
 
-					<div className="flex flex-col justify-center p-6 md:col-span-3 md:p-10">
-						<h2 className="mb-4 text-2xl leading-tight font-bold md:text-3xl lg:text-4xl">
+					<div className="flex flex-col justify-center px-6 py-8 md:px-8 md:py-10 lg:col-span-2 lg:px-10 lg:py-12">
+						<p className="text-secondary mb-4 text-xs font-bold tracking-[0.24em] uppercase">
+							Top story
+						</p>
+						<h2 className="mb-5 text-3xl leading-tight font-bold text-balance md:text-4xl xl:text-5xl">
 							{title}
 						</h2>
-						<p className="text-base-content-secondary mb-4 text-base leading-relaxed md:text-lg">
+						<div className="bg-secondary mb-5 h-1 w-16 rounded-full" />
+						<p className="text-base-content-secondary mb-6 text-base leading-relaxed md:text-lg">
 							{excerpt}
 						</p>
 						<time
 							dateTime={publishedDate.toISOString()}
 							title={fullDate}
-							className="text-base-content-secondary text-sm font-medium"
+							className="text-base-content-secondary text-sm font-semibold tracking-wide"
 						>
 							{relativeDate}
 						</time>


### PR DESCRIPTION
## Summary
- redesign the news listing page with a larger, readable side-by-side hero and stronger content hierarchy
- replace dark featured card styling with lighter cards, gold accent treatment, and improved spacing for easier browsing
- add a dedicated featured section with fallback logic plus staggered fade-in animation for news cards

## Validation
- npm run lint -- \"src/app/(site)/news/page.tsx\" \"src/components/news/NewsHero.tsx\" \"src/components/news/NewsCard.tsx\"
- npm run type:check

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * News page now displays a featured articles section with larger, more prominent cards above the main grid
  * Dynamic featured selection with intelligent fallbacks and de-duplication

* **Style**
  * Introduced fade-in-up animation and staggered card reveal delays
  * Larger card variant and simplified featured badge styling
  * Hero section updated with rounded borders, spacing, hover effects, and improved responsive layouts
* **Layout**
  * Main grid updated (3-column at xl) and featured area uses 1–2 column responsive layout
<!-- end of auto-generated comment: release notes by coderabbit.ai -->