### PR TITLE
feat: support role-specific photo per person context

### DIFF
--- a/src/app/(site)/football/teams/[slug]/page.tsx
+++ b/src/app/(site)/football/teams/[slug]/page.tsx
@@ -9,7 +9,7 @@ import { getSiteSettings } from '@/lib/content';
 import { getTeamBySlug } from '@/lib/content/teamDetail';
 import { getTeamMatches } from '@/lib/matches/matchService';
 import { sanityImageLoader } from '@/lib/sanityImageLoader';
-import { splitPersonName } from '@/lib/transformers/personTransformer';
+import { resolvePersonPhoto, splitPersonName } from '@/lib/transformers/personTransformer';
 import { urlFor } from '@/sanity/lib/image';
 
 type TeamDetailPageProps = {
@@ -76,6 +76,7 @@ export default async function TeamDetailPage({ params }: TeamDetailPageProps) {
 					<div className="grid grid-cols-1 gap-6 md:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4">
 						{team.coachingStaff.map((coach) => {
 							const { firstName, lastName } = splitPersonName(coach.person.name);
+							const photo = resolvePersonPhoto(coach.photo, coach.person.photo);
 
 							return (
 								<CoachCard
@@ -83,12 +84,8 @@ export default async function TeamDetailPage({ params }: TeamDetailPageProps) {
 									firstName={firstName}
 									lastName={lastName}
 									role={coach.title}
-									photoUrl={
-										coach.person.photo?.asset
-											? urlFor(coach.person.photo).width(512).url()
-											: '/img/player-alt.webp'
-									}
-									photoAlt={coach.person.photo.alt || coach.person.name}
+									photoUrl={photo?.asset ? urlFor(photo).width(512).url() : '/img/player-alt.webp'}
+									photoAlt={photo?.alt || coach.person.name}
 								/>
 							);
 						})}

--- a/src/components/committee/CommitteeMemberGrid.tsx
+++ b/src/components/committee/CommitteeMemberGrid.tsx
@@ -1,4 +1,4 @@
-import { splitPersonName } from '@/lib/transformers/personTransformer';
+import { resolvePersonPhoto, splitPersonName } from '@/lib/transformers/personTransformer';
 import { urlFor } from '@/sanity/lib/image';
 import type { CommitteeMember } from '@/types/committee';
 import { CommitteeMemberCard } from './CommitteeMemberCard';
@@ -14,18 +14,15 @@ export function CommitteeMemberGrid({ members }: CommitteeMemberGridProps) {
 		<div className="grid grid-cols-1 gap-6 md:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4">
 			{sortedMembers.map((member) => {
 				const { firstName, lastName } = splitPersonName(member.person.name);
+				const photo = resolvePersonPhoto(member.photo, member.person.photo);
 				return (
 					<CommitteeMemberCard
 						key={member.person._id}
 						firstName={firstName}
 						lastName={lastName}
 						title={member.title}
-						photoUrl={
-							member.person.photo?.asset
-								? urlFor(member.person.photo).width(512).url()
-								: '/img/player-alt.webp'
-						}
-						photoAlt={member.person.photo?.alt || member.person.name}
+						photoUrl={photo?.asset ? urlFor(photo).width(512).url() : '/img/player-alt.webp'}
+						photoAlt={photo?.alt || member.person.name}
 					/>
 				);
 			})}

--- a/src/components/teams/PlayerGrid.tsx
+++ b/src/components/teams/PlayerGrid.tsx
@@ -1,4 +1,4 @@
-import { splitPersonName } from '@/lib/transformers/personTransformer';
+import { resolvePersonPhoto, splitPersonName } from '@/lib/transformers/personTransformer';
 import { urlFor } from '@/sanity/lib/image';
 import type { Player } from '@/types/team';
 import { PlayerCard } from './PlayerCard';
@@ -55,6 +55,7 @@ export function PlayerGrid({ players }: PlayerGridProps) {
 						<div className="grid grid-cols-1 gap-6 md:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4">
 							{positionPlayers.map((player) => {
 								const { firstName, lastName } = splitPersonName(player.person.name);
+								const photo = resolvePersonPhoto(player.photo, player.person.photo);
 								return (
 									<PlayerCard
 										key={player.person._id}
@@ -63,11 +64,9 @@ export function PlayerGrid({ players }: PlayerGridProps) {
 										shirtNumber={player.shirtNumber || 0}
 										position={player.position || ''}
 										photoUrl={
-											player.person?.photo?.asset
-												? urlFor(player.person.photo).width(512).url()
-												: '/img/player-alt.webp'
+											photo?.asset ? urlFor(photo).width(512).url() : '/img/player-alt.webp'
 										}
-										photoAlt={player.person?.photo?.alt || player.person.name}
+										photoAlt={photo?.alt || player.person.name}
 										isCaptain={player.isCaptain || false}
 										isViceCaptain={player.isViceCaptain || false}
 										intro={player.intro}

--- a/src/lib/content/committeePage.ts
+++ b/src/lib/content/committeePage.ts
@@ -37,6 +37,12 @@ export async function getCommitteePageData(): Promise<CommitteePageData | null> 
 			alt
 		},
 		committeeMembers[] {
+			photo {
+				asset-> { _ref, url },
+				alt,
+				crop,
+				hotspot
+			},
 			person-> {
 				_id,
 				name,

--- a/src/lib/content/teamDetail.ts
+++ b/src/lib/content/teamDetail.ts
@@ -24,6 +24,12 @@ export const teamDetailQuery = groq`
     tableUrl,
     description,
     coachingStaff[] {
+      photo {
+        asset-> { _ref, url },
+        alt,
+        crop,
+        hotspot
+      },
       person-> {
         _id,
         name,
@@ -41,6 +47,12 @@ export const teamDetailQuery = groq`
       title
     },
     players[] {
+      photo {
+        asset-> { _ref, url },
+        alt,
+        crop,
+        hotspot
+      },
       person-> {
         _id,
         name,

--- a/src/lib/transformers/personTransformer.ts
+++ b/src/lib/transformers/personTransformer.ts
@@ -1,3 +1,12 @@
+import type { PersonPhoto } from '@/types/team';
+
+export function resolvePersonPhoto(
+	rolePhoto: PersonPhoto | undefined,
+	personPhoto: PersonPhoto
+): PersonPhoto {
+	return rolePhoto ?? personPhoto;
+}
+
 export function splitPersonName(fullName: string): { firstName: string; lastName: string } {
 	const parts = fullName.trim().split(' ');
 	if (parts.length === 1) {

--- a/src/lib/transformers/personTransformer.ts
+++ b/src/lib/transformers/personTransformer.ts
@@ -1,7 +1,7 @@
 import type { PersonPhoto } from '@/types/team';
 
 export function resolvePersonPhoto(
-	rolePhoto: PersonPhoto | undefined,
+	rolePhoto: PersonPhoto | null | undefined,
 	personPhoto: PersonPhoto
 ): PersonPhoto {
 	return rolePhoto ?? personPhoto;

--- a/src/sanity/schema/coach.ts
+++ b/src/sanity/schema/coach.ts
@@ -18,7 +18,14 @@ export const coach = defineType({
 			type: 'image',
 			description: 'Optional. Use a different photo when this person appears as a coach.',
 			options: { hotspot: true },
-			fields: [{ name: 'alt', type: 'string', title: 'Alt Text' }]
+			fields: [
+				defineField({
+					name: 'alt',
+					type: 'string',
+					title: 'Alt Text',
+					validation: (Rule) => Rule.required()
+				})
+			]
 		}),
 		defineField({
 			name: 'title',

--- a/src/sanity/schema/coach.ts
+++ b/src/sanity/schema/coach.ts
@@ -13,6 +13,14 @@ export const coach = defineType({
 			validation: (Rule) => Rule.required()
 		}),
 		defineField({
+			name: 'photo',
+			title: 'Role Photo',
+			type: 'image',
+			description: 'Optional. Use a different photo when this person appears as a coach.',
+			options: { hotspot: true },
+			fields: [{ name: 'alt', type: 'string', title: 'Alt Text' }]
+		}),
+		defineField({
 			name: 'title',
 			title: 'Coaching Title',
 			type: 'string',

--- a/src/sanity/schema/committeeMember.ts
+++ b/src/sanity/schema/committeeMember.ts
@@ -13,6 +13,15 @@ export const committeeMember = defineType({
 			validation: (Rule) => Rule.required()
 		}),
 		defineField({
+			name: 'photo',
+			title: 'Role Photo',
+			type: 'image',
+			description:
+				'Optional. Use a different photo when this person appears as a committee member.',
+			options: { hotspot: true },
+			fields: [{ name: 'alt', type: 'string', title: 'Alt Text' }]
+		}),
+		defineField({
 			name: 'title',
 			title: 'Title',
 			type: 'string',

--- a/src/sanity/schema/committeeMember.ts
+++ b/src/sanity/schema/committeeMember.ts
@@ -19,7 +19,14 @@ export const committeeMember = defineType({
 			description:
 				'Optional. Use a different photo when this person appears as a committee member.',
 			options: { hotspot: true },
-			fields: [{ name: 'alt', type: 'string', title: 'Alt Text' }]
+			fields: [
+				defineField({
+					name: 'alt',
+					type: 'string',
+					title: 'Alt Text',
+					validation: (Rule) => Rule.required()
+				})
+			]
 		}),
 		defineField({
 			name: 'title',

--- a/src/sanity/schema/player.ts
+++ b/src/sanity/schema/player.ts
@@ -20,6 +20,14 @@ export const player = defineType({
 			validation: (Rule) => Rule.required()
 		}),
 		defineField({
+			name: 'photo',
+			title: 'Role Photo',
+			type: 'image',
+			description: 'Optional. Use a different photo when this person appears as a player.',
+			options: { hotspot: true },
+			fields: [{ name: 'alt', type: 'string', title: 'Alt Text' }]
+		}),
+		defineField({
 			name: 'shirtNumber',
 			title: 'Shirt Number',
 			type: 'number',

--- a/src/sanity/schema/player.ts
+++ b/src/sanity/schema/player.ts
@@ -25,7 +25,14 @@ export const player = defineType({
 			type: 'image',
 			description: 'Optional. Use a different photo when this person appears as a player.',
 			options: { hotspot: true },
-			fields: [{ name: 'alt', type: 'string', title: 'Alt Text' }]
+			fields: [
+				defineField({
+					name: 'alt',
+					type: 'string',
+					title: 'Alt Text',
+					validation: (Rule) => Rule.required()
+				})
+			]
 		}),
 		defineField({
 			name: 'shirtNumber',

--- a/src/types/committee.ts
+++ b/src/types/committee.ts
@@ -1,7 +1,8 @@
-import type { Person } from './team';
+import type { Person, PersonPhoto } from './team';
 
 export type CommitteeMember = {
 	person: Person;
+	photo?: PersonPhoto;
 	title: string;
 	order: number;
 };

--- a/src/types/team.ts
+++ b/src/types/team.ts
@@ -30,28 +30,32 @@ export type AgeGroup =
 
 export type TabCategory = 'seniors' | 'reserves' | 'juniors' | 'masters' | 'metros';
 
+export type PersonPhoto = {
+	asset: {
+		_ref: string;
+		url: string;
+	};
+	alt: string;
+	crop?: { top: number; bottom: number; left: number; right: number };
+	hotspot?: { x: number; y: number; width: number; height: number };
+};
+
 export interface Person {
 	_id: string;
 	name: string;
-	photo: {
-		asset: {
-			_ref: string;
-			url: string;
-		};
-		alt: string;
-		crop?: { top: number; bottom: number; left: number; right: number };
-		hotspot?: { x: number; y: number; width: number; height: number };
-	};
+	photo: PersonPhoto;
 	dateOfBirth?: string;
 }
 
 export interface Coach {
 	person: Person;
+	photo?: PersonPhoto;
 	title: string;
 }
 
 export interface Player {
 	person: Person;
+	photo?: PersonPhoto;
 	shirtNumber?: number;
 	position?: string;
 	areaOfPitch?: 'goalkeeper' | 'defender' | 'midfielder' | 'forward';


### PR DESCRIPTION
## Summary
- Adds an optional **Role Photo** field to `coach`, `player`, and `committeeMember` Sanity schema objects
- When set, the role photo overrides the person's default photo in that context (e.g. action shot as a player, headshot as a coach)
- Extracts a shared `PersonPhoto` type and adds a `resolvePersonPhoto()` helper to centralise the fallback logic
- GROQ queries updated to fetch the wrapper-level photo alongside the person photo

## Test plan
- [ ] In Sanity Studio, open a coach/player/committee member entry and confirm the "Role Photo" field appears
- [ ] Set a Role Photo on one entry and verify it renders on the website instead of the person's default photo
- [ ] Verify existing entries without a Role Photo still display the person's default photo correctly
- [ ] Check light and dark themes render correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Users can now upload individual photos for coaches, committee members, and players.
  * The system automatically uses role-specific photos when available, falling back to default photos otherwise.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->