### PR TITLE
fix: prevent venue icon squashing and link to Google Maps

### DIFF
--- a/src/components/matches/MatchCardDesktop.tsx
+++ b/src/components/matches/MatchCardDesktop.tsx
@@ -41,10 +41,15 @@ export function MatchCardDesktop({ fixture, formattedDate, formattedTime }: Matc
 							{formattedDate} {formattedTime}
 						</span>
 					</time>
-					<div className="text-base-content/70 flex items-center gap-1.5 text-sm">
-						<MapPin className="h-4 w-4" aria-hidden="true" />
+					<a
+						href={`https://www.google.com/maps/dir/?api=1&destination=${encodeURIComponent(fixture.address)}`}
+						target="_blank"
+						rel="noopener noreferrer"
+						className="text-base-content/70 hover:text-base-content flex items-start gap-1.5 text-sm transition-colors"
+					>
+						<MapPin className="mt-0.5 h-4 w-4 shrink-0" aria-hidden="true" />
 						<span>{fixture.address}</span>
-					</div>
+					</a>
 				</div>
 
 				{/* Column 2: Home Team Name (right-aligned) */}

--- a/src/components/matches/MatchCardMobile.tsx
+++ b/src/components/matches/MatchCardMobile.tsx
@@ -59,10 +59,15 @@ export function MatchCardMobile({ fixture, formattedDate, formattedTime }: Match
 			{isWashout && <span className="badge badge-neutral">Postponed</span>}
 
 			{/* Venue */}
-			<div className="text-base-content/60 grid grid-cols-[auto_1fr] items-start gap-1.5 text-sm">
-				<MapPin className="mt-0.5 h-4 w-4" aria-hidden="true" />
+			<a
+				href={`https://www.google.com/maps/dir/?api=1&destination=${encodeURIComponent(fixture.address)}`}
+				target="_blank"
+				rel="noopener noreferrer"
+				className="text-base-content/60 hover:text-base-content grid grid-cols-[auto_1fr] items-start gap-1.5 text-sm transition-colors"
+			>
+				<MapPin className="mt-0.5 h-4 w-4 shrink-0" aria-hidden="true" />
 				<span>{fixture.address}</span>
-			</div>
+			</a>
 		</div>
 	);
 }


### PR DESCRIPTION
## Summary
- Added `shrink-0` to the `MapPin` icon so it maintains its size when the address is long
- Wrapped the venue address in a Google Maps directions link (opens in new tab)

## Test plan
- [ ] Check fixtures page on mobile and desktop — icon should not squash on long addresses
- [ ] Click a venue address and confirm it opens Google Maps directions

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Match venue information is now clickable, automatically directing users to Google Maps with the venue address pre-filled.
  * Links open in a new browser tab for seamless navigation.
  * Enhanced interactivity with hover styling and smooth color transitions on both desktop and mobile layouts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->