### PR TITLE
feat: refactor crawlers to support batch processing with single browser session

### DIFF
--- a/.agents/skills/dribl-crawling/SKILL.md
+++ b/.agents/skills/dribl-crawling/SKILL.md
@@ -94,7 +94,10 @@ export async function crawlFixtures(teams: CrawlFixturesTeamOptions[]): Promise<
 
 	try {
 		browser = await chromium.launch({ headless: false, channel: 'chrome' });
-		const context = await browser.newContext({ userAgent: '...', viewport: { width: 1280, height: 720 } });
+		const context = await browser.newContext({
+			userAgent: '...',
+			viewport: { width: 1280, height: 720 }
+		});
 		const page = await context.newPage();
 
 		const responses: Response[] = [];
@@ -106,15 +109,31 @@ export async function crawlFixtures(teams: CrawlFixturesTeamOptions[]): Promise<
 
 		for (const team of teams) {
 			try {
-				const filterArgs = { league: team.league, season: team.season, competition: team.competition };
+				const filterArgs = {
+					league: team.league,
+					season: team.season,
+					competition: team.competition
+				};
 
 				// Crawl fixtures (upcoming)
 				responses.length = 0;
-				await crawlPage({ page, responses, url: fixturesBaseUrl, outputDir: `.../${team.team}`, filterArgs });
+				await crawlPage({
+					page,
+					responses,
+					url: fixturesBaseUrl,
+					outputDir: `.../${team.team}`,
+					filterArgs
+				});
 
 				// Crawl results (past + scores)
 				responses.length = 0;
-				await crawlPage({ page, responses, url: resultsBaseUrl, outputDir: `.../${team.team}`, filterArgs });
+				await crawlPage({
+					page,
+					responses,
+					url: resultsBaseUrl,
+					outputDir: `.../${team.team}`,
+					filterArgs
+				});
 
 				responses.length = 0;
 			} catch (error) {
@@ -188,17 +207,19 @@ export async function crawlTable(teams: CrawlTableTeamOptions[]): Promise<void> 
 
 	try {
 		browser = await chromium.launch({ headless: false, channel: 'chrome' });
-		const context = await browser.newContext({ userAgent: '...', viewport: { width: 1280, height: 720 } });
+		const context = await browser.newContext({
+			userAgent: '...',
+			viewport: { width: 1280, height: 720 }
+		});
 		const page = await context.newPage();
 
 		for (const team of teams) {
 			try {
 				const [response] = await Promise.all([
-					page.waitForResponse(
-						(r) => r.url().includes('mc-api.dribl.com/api/ladders') && r.ok(),
-						{ timeout: 60_000 }
-					),
-					page.goto(team.tableUrl, { waitUntil: 'domcontentloaded' }),
+					page.waitForResponse((r) => r.url().includes('mc-api.dribl.com/api/ladders') && r.ok(), {
+						timeout: 60_000
+					}),
+					page.goto(team.tableUrl, { waitUntil: 'domcontentloaded' })
 				]);
 
 				const rawData = await response.json();

--- a/.agents/skills/dribl-crawling/SKILL.md
+++ b/.agents/skills/dribl-crawling/SKILL.md
@@ -33,7 +33,7 @@ dribl API → data/external/clubs/ (raw) → transform → data/clubs/ (validate
 
 ## Clubs Extraction
 
-**Reference**: `bin/crawlClubs.ts`
+**Reference**: `bin/commands/crawlClubs.ts`
 
 **Pattern:**
 
@@ -81,23 +81,64 @@ writeFileSync(outputPath, JSON.stringify(validated, null, '\t') + '\n');
 
 ## Fixtures Extraction
 
-**Pattern (implemented in bin/crawlFixtures.ts):**
+**Reference**: `bin/commands/crawlFixtures.ts`
 
-**Steps:**
+**Single browser session for all teams.** The browser launches once, then each team's pages are crawled by reusing the same page instance. Each `page.goto()` resets the SPA's filter state, so `applyFilters` is idempotent on every navigation.
 
-1. Navigate to https://fv.dribl.com/fixtures/
-2. Wait for SPA to load (`waitUntil: 'domcontentloaded'`)
-3. Apply filters (REQUIRED):
-   - Season (e.g., "2025")
-   - Competition (e.g., "FFV")
-   - League (e.g., "state-league-2-men-s-north-west")
-4. Intercept `/api/fixtures` responses
-5. Handle pagination:
-   - Detect "Load more" button in DOM
-   - Click button to load next chunk
-   - Wait for new API response
-   - Repeat until no more data
-6. Save each chunk as `chunk-{index}.json`
+**Pattern:**
+
+```typescript
+export async function crawlFixtures(teams: CrawlFixturesTeamOptions[]): Promise<void> {
+	let browser: Browser | undefined;
+	const failures: string[] = [];
+
+	try {
+		browser = await chromium.launch({ headless: false, channel: 'chrome' });
+		const context = await browser.newContext({ userAgent: '...', viewport: { width: 1280, height: 720 } });
+		const page = await context.newPage();
+
+		const responses: Response[] = [];
+		page.on('response', async (response) => {
+			if (response.url().startsWith(driblApiBaseUrl) && response.ok()) {
+				responses.push(response);
+			}
+		});
+
+		for (const team of teams) {
+			try {
+				const filterArgs = { league: team.league, season: team.season, competition: team.competition };
+
+				// Crawl fixtures (upcoming)
+				responses.length = 0;
+				await crawlPage({ page, responses, url: fixturesBaseUrl, outputDir: `.../${team.team}`, filterArgs });
+
+				// Crawl results (past + scores)
+				responses.length = 0;
+				await crawlPage({ page, responses, url: resultsBaseUrl, outputDir: `.../${team.team}`, filterArgs });
+
+				responses.length = 0;
+			} catch (error) {
+				failures.push(team.team);
+			}
+		}
+	} finally {
+		if (browser) await browser.close();
+	}
+
+	if (failures.length > 0) {
+		throw new Error(`Crawl failed for teams: ${failures.join(', ')}`);
+	}
+}
+```
+
+**Steps per team:**
+
+1. Reset `responses.length = 0`
+2. Navigate to `https://fv.dribl.com/fixtures/` — SPA loads with default filters
+3. Apply filters: Season → Competition → League (via `clickFilterByText`)
+4. Paginate via "Load more..." button until exhausted
+5. Save each API response chunk as `chunk-{index}.json`
+6. Reset responses and repeat for `https://fv.dribl.com/results/`
 
 **API endpoint:**
 
@@ -109,19 +150,93 @@ writeFileSync(outputPath, JSON.stringify(validated, null, '\t') + '\n');
 **Output:**
 
 - Path: `data/external/fixtures/{team}/chunk-0.json`, `chunk-1.json`, etc.
+- Path: `data/external/results/{team}/chunk-0.json`, `chunk-1.json`, etc.
 - Format: Multiple JSON files (one per "Load more" click)
-- Naming: `chunk-{index}.json` where index starts at 0
 
 **CLI args:**
 
-- `--team <slug>` (required) - Team slug for output folder (e.g., "state-league-2-men-s-north-west")
-- `--league <slug>` (required) - League slug for filtering (e.g., "State League 2 Men's - North-West")
-- `--season <year>` (optional, default to current year)
-- `--competition <id>` (optional, default to FFV)
+- `-t, --team <slug>` — repeatable; filters Sanity teams to these slugs (e.g., `-t slug1 -t slug2`)
+- `-l, --league <name>` — manual mode only; requires exactly one `-t`
+- `-s, --season <year>` (optional, default to current year)
+- `-c, --competition <id>` (optional, default to FFV)
+
+**CLI usage examples:**
+
+```bash
+# All Sanity teams (single browser session)
+npm run crawl:fixtures
+
+# Specific teams from Sanity (single browser session)
+npm run crawl:fixtures -- -t state-league-2-men-s-north-west -t reserves
+
+# Manual mode: single team with explicit league
+npm run crawl:fixtures -- -t my-team -l "State League 2 Men's - North-West"
+```
+
+## Table Extraction
+
+**Reference**: `bin/commands/crawlTable.ts`
+
+**Single browser session for all teams.** Each team has its own Dribl ladder URL. The browser navigates to each URL in turn and captures the single API response using `page.waitForResponse()` (same pattern as `crawlClubs.ts`).
+
+**Pattern:**
+
+```typescript
+export async function crawlTable(teams: CrawlTableTeamOptions[]): Promise<void> {
+	let browser: Browser | undefined;
+	const failures: string[] = [];
+
+	try {
+		browser = await chromium.launch({ headless: false, channel: 'chrome' });
+		const context = await browser.newContext({ userAgent: '...', viewport: { width: 1280, height: 720 } });
+		const page = await context.newPage();
+
+		for (const team of teams) {
+			try {
+				const [response] = await Promise.all([
+					page.waitForResponse(
+						(r) => r.url().includes('mc-api.dribl.com/api/ladders') && r.ok(),
+						{ timeout: 60_000 }
+					),
+					page.goto(team.tableUrl, { waitUntil: 'domcontentloaded' }),
+				]);
+
+				const rawData = await response.json();
+				const validated = externalTableApiResponseSchema.parse(rawData);
+				// save to data/external/table/{team}.json
+			} catch (error) {
+				failures.push(team.team);
+			}
+		}
+	} finally {
+		if (browser) await browser.close();
+	}
+
+	if (failures.length > 0) {
+		throw new Error(`Crawl failed for teams: ${failures.join(', ')}`);
+	}
+}
+```
+
+**API endpoint:**
+
+- URL: `https://mc-api.dribl.com/api/ladders`
+- Response: JSON with `data` array of ladder entries
+- Validation: `externalTableApiResponseSchema` (src/types/table.ts)
+
+**Output:**
+
+- Path: `data/external/table/{team}.json`
+- Format: Single JSON file per team
+
+**CLI args:**
+
+- `-t, --team <slug>` — repeatable; filters Sanity teams to these slugs
+- `-u, --table-url <url>` — manual mode only; requires exactly one `-t`
 
 ## Clubs Transformation
 
-**Reference**: `bin/syncClubs.ts`
+**Reference**: `bin/commands/syncClubs.ts`
 
 **Pattern:**
 
@@ -167,7 +282,7 @@ writeFileSync(CLUBS_FILE_PATH, JSON.stringify({ clubs: mergedClubs }, null, '\t'
 
 ## Fixtures Transformation
 
-**Reference**: `bin/syncFixtures.ts`
+**Reference**: `bin/commands/syncFixtures.ts`
 
 **Pattern:**
 
@@ -263,7 +378,7 @@ writeFileSync(outputPath, JSON.stringify(fixtureData, null, '\t'));
 
 ## CI Integration
 
-**Reference**: `.github/workflows/crawl-clubs.yml`
+**Reference**: `.github/workflows/crawl.yml`
 
 **Linux setup (GitHub Actions):**
 
@@ -271,25 +386,26 @@ writeFileSync(outputPath, JSON.stringify(fixtureData, null, '\t'));
 - name: Install Chrome
   run: npx playwright install --with-deps chrome
 
-- name: Crawl clubs
-  run: npm run crawl:clubs:ci -- ${{ inputs.url && format('--url "{0}"', inputs.url) || '' }}
+- name: Crawl fixtures
+  run: npm run crawl:fixtures:ci
 ```
 
 **Key points:**
 
-- Use `xvfb-run` prefix on Linux for headless Chrome (e.g., `xvfb-run npm run crawl:clubs`)
+- Use `xvfb-run --auto-servernum` prefix on Linux for headless Chrome (e.g., `xvfb-run --auto-servernum tsx bin/wsc.ts crawl fixtures`)
 - Install with `--with-deps` flag to get system dependencies
-- Set appropriate timeout (5 min for clubs, may need more for fixtures)
-- Upload artifacts for data files
+- No team args needed in CI — all Sanity teams are crawled in one browser session
 
 **Package.json scripts pattern:**
 
 ```json
 {
-	"crawl:clubs": "tsx bin/crawlClubs.ts",
-	"crawl:clubs:ci": "xvfb-run tsx bin/crawlClubs.ts",
-	"sync:clubs": "tsx bin/syncClubs.ts",
-	"sync:fixtures": "tsx bin/syncFixtures.ts"
+	"crawl:fixtures": "tsx bin/wsc.ts crawl fixtures",
+	"crawl:fixtures:ci": "xvfb-run --auto-servernum tsx bin/wsc.ts crawl fixtures",
+	"crawl:table": "tsx bin/wsc.ts crawl table",
+	"crawl:table:ci": "xvfb-run --auto-servernum tsx bin/wsc.ts crawl table",
+	"sync:clubs": "tsx bin/wsc.ts sync clubs",
+	"sync:fixtures": "tsx bin/wsc.ts sync fixtures"
 }
 ```
 
@@ -297,26 +413,22 @@ writeFileSync(outputPath, JSON.stringify(fixtureData, null, '\t'));
 
 **Logging:**
 
-- Use emoji logging for clarity:
-  - ✓ / ✅ - Success
-  - ❌ - Error
-  - 📂 - File operations
-  - 🔄 - Processing/transformation
+- Use pino logger with child loggers per module
 - Log counts and progress for large operations
 
 **Error handling:**
 
-- Try/catch at top level
-- Special handling for ZodError (print issues)
-- Exit with code 1 on failure
-- Close browser in finally block
+- Per-team failures are caught and collected — the session continues to the next team
+- A single throw at the end signals partial failure to the caller
+- Browser closes in `finally` block regardless of failures
+- Special handling for ZodError (print issues) and missing Playwright executable
 
 **File operations:**
 
 - Always use `mkdirSync(path, { recursive: true })` before writing
 - Format JSON with tabs: `JSON.stringify(data, null, '\t')`
 - Add newline at end of file: `content + '\n'`
-- Use absolute paths with `resolve(__dirname, '../relative/path')`
+- Use absolute paths with `resolve(currentDir, '../relative/path')`
 
 **Data separation:**
 
@@ -333,9 +445,9 @@ writeFileSync(outputPath, JSON.stringify(fixtureData, null, '\t'));
 **CLI arguments:**
 
 - Use Commander library for consistent CLI parsing
-- Define options with `.option()` or `.requiredOption()`
-- Provide defaults for optional args
-- Commander auto-generates help text and validates required args
+- `-t, --team` is repeatable (collector function): `-t slug1 -t slug2`
+- Manual mode requires exactly one `-t` plus the URL/league option
+- Sanity mode (no manual options) fetches team config from CMS
 
 ## Common Patterns
 
@@ -373,14 +485,23 @@ incoming.forEach((item) => map.set(item.id, item)); // update or add
 const merged = Array.from(map.values());
 ```
 
-**Browser cleanup:**
+**Single-browser session pattern:**
 
 ```typescript
 let browser: Browser | undefined;
+const failures: string[] = [];
 try {
-  browser = await chromium.launch(...);
-  // work
+	browser = await chromium.launch(...);
+	const page = await (await browser.newContext(...)).newPage();
+	for (const team of teams) {
+		try {
+			// work per team
+		} catch (error) {
+			failures.push(team.slug);
+		}
+	}
 } finally {
-  if (browser) await browser.close();
+	if (browser) await browser.close();
 }
+if (failures.length > 0) throw new Error(`Failed: ${failures.join(', ')}`);
 ```

--- a/bin/commands/crawlFixtures.ts
+++ b/bin/commands/crawlFixtures.ts
@@ -393,18 +393,30 @@ export async function crawlFixtures(teams: CrawlFixturesTeamOptions[]): Promise<
 				const filterArgs: FilterArgs = {
 					league: team.league,
 					season: team.season,
-					competition: team.competition,
+					competition: team.competition
 				};
 
 				// Crawl fixtures (upcoming)
 				responses.length = 0;
 				const fixturesOutputDir = resolve(currentDir, `../../data/external/fixtures/${team.team}`);
-				await crawlPage({ page, responses, url: fixturesBaseUrl, outputDir: fixturesOutputDir, filterArgs });
+				await crawlPage({
+					page,
+					responses,
+					url: fixturesBaseUrl,
+					outputDir: fixturesOutputDir,
+					filterArgs
+				});
 
 				// Crawl results (past + scores)
 				responses.length = 0;
 				const resultsOutputDir = resolve(currentDir, `../../data/external/results/${team.team}`);
-				await crawlPage({ page, responses, url: resultsBaseUrl, outputDir: resultsOutputDir, filterArgs });
+				await crawlPage({
+					page,
+					responses,
+					url: resultsBaseUrl,
+					outputDir: resultsOutputDir,
+					filterArgs
+				});
 
 				responses.length = 0;
 				log.info({ team: team.team, league: team.league }, 'crawl completed');

--- a/bin/commands/crawlFixtures.ts
+++ b/bin/commands/crawlFixtures.ts
@@ -12,7 +12,7 @@ const fixturesBaseUrl = 'https://fv.dribl.com/fixtures/';
 const resultsBaseUrl = 'https://fv.dribl.com/results/';
 const driblApiBaseUrl = 'https://mc-api.dribl.com/api/';
 
-export type CrawlFixturesOptions = {
+export type CrawlFixturesTeamOptions = {
 	team: string;
 	league: string;
 	season?: string;
@@ -350,9 +350,24 @@ async function crawlPage({
 	}
 }
 
-export async function crawlFixtures({ team, league, season, competition }: CrawlFixturesOptions) {
-	log.info('launching browser');
+function logTeamError(error: unknown, team: string): void {
+	if (error instanceof ZodError) {
+		log.error({ issues: error.issues, team }, 'crawl failed: validation error');
+	} else if (error instanceof Error) {
+		log.error({ err: error, team }, 'crawl failed');
+
+		if (error.message.includes("Executable doesn't exist")) {
+			log.info('install Playwright browsers with: npx playwright install --with-deps chrome');
+		}
+	} else {
+		log.error({ err: error, team }, 'crawl failed: unknown error');
+	}
+}
+
+export async function crawlFixtures(teams: CrawlFixturesTeamOptions[]): Promise<void> {
+	log.info({ count: teams.length }, 'launching browser');
 	let browser: Browser | undefined;
+	const failures: string[] = [];
 
 	try {
 		browser = await chromium.launch({ headless: false, channel: 'chrome' });
@@ -371,50 +386,42 @@ export async function crawlFixtures({ team, league, season, competition }: Crawl
 			}
 		});
 
-		const filterArgs: FilterArgs = { league, season, competition };
+		for (const team of teams) {
+			try {
+				log.info({ team: team.team, league: team.league }, 'crawling team');
 
-		// Crawl fixtures (upcoming)
-		const fixturesOutputDir = resolve(currentDir, `../../data/external/fixtures/${team}`);
-		await crawlPage({
-			page,
-			responses,
-			url: fixturesBaseUrl,
-			outputDir: fixturesOutputDir,
-			filterArgs
-		});
+				const filterArgs: FilterArgs = {
+					league: team.league,
+					season: team.season,
+					competition: team.competition,
+				};
 
-		// Reset responses before crawling results
-		responses.length = 0;
+				// Crawl fixtures (upcoming)
+				responses.length = 0;
+				const fixturesOutputDir = resolve(currentDir, `../../data/external/fixtures/${team.team}`);
+				await crawlPage({ page, responses, url: fixturesBaseUrl, outputDir: fixturesOutputDir, filterArgs });
 
-		// Crawl results (past + scores)
-		const resultsOutputDir = resolve(currentDir, `../../data/external/results/${team}`);
-		await crawlPage({
-			page,
-			responses,
-			url: resultsBaseUrl,
-			outputDir: resultsOutputDir,
-			filterArgs
-		});
+				// Crawl results (past + scores)
+				responses.length = 0;
+				const resultsOutputDir = resolve(currentDir, `../../data/external/results/${team.team}`);
+				await crawlPage({ page, responses, url: resultsBaseUrl, outputDir: resultsOutputDir, filterArgs });
 
-		log.info({ team, league }, 'crawl completed');
-	} catch (error) {
-		if (error instanceof ZodError) {
-			log.error({ issues: error.issues }, 'crawl failed: validation error');
-		} else if (error instanceof Error) {
-			log.error({ err: error }, 'crawl failed');
-
-			if (error.message.includes("Executable doesn't exist")) {
-				log.info('install Playwright browsers with: npx playwright install --with-deps chrome');
+				responses.length = 0;
+				log.info({ team: team.team, league: team.league }, 'crawl completed');
+			} catch (error) {
+				logTeamError(error, team.team);
+				failures.push(team.team);
 			}
-		} else {
-			log.error({ err: error }, 'crawl failed: unknown error');
 		}
-
-		throw error;
 	} finally {
 		if (browser) {
 			await browser.close();
 			log.info('browser closed');
 		}
+	}
+
+	if (failures.length > 0) {
+		log.error({ failures }, 'crawl failed for some teams');
+		throw new Error(`Crawl failed for teams: ${failures.join(', ')}`);
 	}
 }

--- a/bin/commands/crawlTable.ts
+++ b/bin/commands/crawlTable.ts
@@ -45,6 +45,9 @@ export async function crawlTable(teams: CrawlTableTeamOptions[]): Promise<void> 
 		});
 		const page = await context.newPage();
 
+		const outputDir = resolve(currentDir, `../../data/external/table`);
+		mkdirSync(outputDir, { recursive: true });
+
 		for (const team of teams) {
 			try {
 				log.info({ team: team.team, tableUrl: team.tableUrl }, 'crawling table');
@@ -63,9 +66,6 @@ export async function crawlTable(teams: CrawlTableTeamOptions[]): Promise<void> 
 				if (!/^[a-z0-9][a-z0-9-_]*$/i.test(team.team)) {
 					throw new Error(`Invalid team slug for filename: ${team.team}`);
 				}
-
-				const outputDir = resolve(currentDir, `../../data/external/table`);
-				mkdirSync(outputDir, { recursive: true });
 
 				const outputPath = resolve(outputDir, `${team.team}.json`);
 				writeFileSync(outputPath, JSON.stringify(validated, null, '\t') + '\n', 'utf-8');

--- a/bin/commands/crawlTable.ts
+++ b/bin/commands/crawlTable.ts
@@ -50,11 +50,10 @@ export async function crawlTable(teams: CrawlTableTeamOptions[]): Promise<void> 
 				log.info({ team: team.team, tableUrl: team.tableUrl }, 'crawling table');
 
 				const [response] = await Promise.all([
-					page.waitForResponse(
-						(r) => r.url().includes(driblLaddersApiUrl) && r.ok(),
-						{ timeout: 60_000 }
-					),
-					page.goto(team.tableUrl, { waitUntil: 'domcontentloaded' }),
+					page.waitForResponse((r) => r.url().includes(driblLaddersApiUrl) && r.ok(), {
+						timeout: 60_000
+					}),
+					page.goto(team.tableUrl, { waitUntil: 'domcontentloaded' })
 				]);
 
 				const rawData = await response.json();

--- a/bin/commands/crawlTable.ts
+++ b/bin/commands/crawlTable.ts
@@ -10,16 +10,31 @@ const log = logger.child({ module: 'crawl-table' });
 
 const driblLaddersApiUrl = 'mc-api.dribl.com/api/ladders';
 
-export type CrawlTableOptions = {
+export type CrawlTableTeamOptions = {
 	team: string;
 	tableUrl: string;
 };
 
 const currentDir = dirname(fileURLToPath(import.meta.url));
 
-export async function crawlTable({ team, tableUrl }: CrawlTableOptions) {
-	log.info({ team, tableUrl }, 'launching browser');
+function logTeamError(error: unknown, team: string): void {
+	if (error instanceof ZodError) {
+		log.error({ issues: error.issues, team }, 'crawl failed: validation error');
+	} else if (error instanceof Error) {
+		log.error({ err: error, team }, 'crawl failed');
+
+		if (error.message.includes("Executable doesn't exist")) {
+			log.info('install Playwright browsers with: npx playwright install --with-deps chrome');
+		}
+	} else {
+		log.error({ err: error, team }, 'crawl failed: unknown error');
+	}
+}
+
+export async function crawlTable(teams: CrawlTableTeamOptions[]): Promise<void> {
+	log.info({ count: teams.length }, 'launching browser');
 	let browser: Browser | undefined;
+	const failures: string[] = [];
 
 	try {
 		browser = await chromium.launch({ headless: false, channel: 'chrome' });
@@ -30,64 +45,48 @@ export async function crawlTable({ team, tableUrl }: CrawlTableOptions) {
 		});
 		const page = await context.newPage();
 
-		let capturedResponse: unknown = null;
+		for (const team of teams) {
+			try {
+				log.info({ team: team.team, tableUrl: team.tableUrl }, 'crawling table');
 
-		page.on('response', async (response) => {
-			if (response.url().includes(driblLaddersApiUrl) && response.ok()) {
-				try {
-					capturedResponse = await response.json();
-					log.debug({ url: response.url() }, 'API response captured');
-				} catch (err) {
-					log.warn({ err }, 'failed to parse API response body');
+				const [response] = await Promise.all([
+					page.waitForResponse(
+						(r) => r.url().includes(driblLaddersApiUrl) && r.ok(),
+						{ timeout: 60_000 }
+					),
+					page.goto(team.tableUrl, { waitUntil: 'domcontentloaded' }),
+				]);
+
+				const rawData = await response.json();
+				const validated = externalTableApiResponseSchema.parse(rawData);
+				log.debug({ entries: validated.data.length }, 'response validated');
+
+				if (!/^[a-z0-9][a-z0-9-_]*$/i.test(team.team)) {
+					throw new Error(`Invalid team slug for filename: ${team.team}`);
 				}
+
+				const outputDir = resolve(currentDir, `../../data/external/table`);
+				mkdirSync(outputDir, { recursive: true });
+
+				const outputPath = resolve(outputDir, `${team.team}.json`);
+				writeFileSync(outputPath, JSON.stringify(validated, null, '\t') + '\n', 'utf-8');
+				log.debug({ outputPath }, 'table data written');
+
+				log.info({ team: team.team }, 'crawl completed');
+			} catch (error) {
+				logTeamError(error, team.team);
+				failures.push(team.team);
 			}
-		});
-
-		log.debug({ url: tableUrl }, 'navigating to ladder page');
-		await page.goto(tableUrl, { waitUntil: 'domcontentloaded' });
-
-		const deadline = Date.now() + 60_000;
-		while (!capturedResponse && Date.now() < deadline) {
-			await page.waitForTimeout(500);
 		}
-
-		if (!capturedResponse) {
-			throw new Error(`Timed out waiting for API response from ${driblLaddersApiUrl}`);
-		}
-
-		const validated = externalTableApiResponseSchema.parse(capturedResponse);
-		log.debug({ entries: validated.data.length }, 'response validated');
-
-		if (!/^[a-z0-9][a-z0-9-_]*$/i.test(team)) {
-			throw new Error(`Invalid team slug for filename: ${team}`);
-		}
-
-		const outputDir = resolve(currentDir, `../../data/external/table`);
-		mkdirSync(outputDir, { recursive: true });
-
-		const outputPath = resolve(outputDir, `${team}.json`);
-		writeFileSync(outputPath, JSON.stringify(validated, null, '\t') + '\n', 'utf-8');
-		log.debug({ outputPath }, 'table data written');
-
-		log.info({ team }, 'crawl completed');
-	} catch (error) {
-		if (error instanceof ZodError) {
-			log.error({ issues: error.issues }, 'crawl failed: validation error');
-		} else if (error instanceof Error) {
-			log.error({ err: error }, 'crawl failed');
-
-			if (error.message.includes("Executable doesn't exist")) {
-				log.info('install Playwright browsers with: npx playwright install --with-deps chrome');
-			}
-		} else {
-			log.error({ err: error }, 'crawl failed: unknown error');
-		}
-
-		throw error;
 	} finally {
 		if (browser) {
 			await browser.close();
 			log.info('browser closed');
 		}
+	}
+
+	if (failures.length > 0) {
+		log.error({ failures }, 'crawl failed for some teams');
+		throw new Error(`Crawl failed for teams: ${failures.join(', ')}`);
 	}
 }

--- a/bin/wsc.ts
+++ b/bin/wsc.ts
@@ -55,8 +55,8 @@ crawl
 				return;
 			}
 
-			if (teams.length > 1 && options.league) {
-				log.error('--league cannot be combined with multiple --team values');
+			if (options.league && teams.length !== 1) {
+				log.error({ teamCount: teams.length }, '--league requires exactly one --team');
 				process.exit(1);
 			}
 
@@ -73,6 +73,12 @@ crawl
 			if (filtered.length === 0) {
 				log.error({ slugs: teams }, 'no matching teams found in Sanity config');
 				process.exit(1);
+			}
+
+			if (teams.length > 0 && filtered.length < teams.length) {
+				const matched = new Set(filtered.map((t) => t.slug));
+				const missing = teams.filter((slug) => !matched.has(slug));
+				log.warn({ missing }, 'some --team slugs did not match any Sanity team');
 			}
 
 			log.info({ count: filtered.length }, 'crawling fixtures for teams from Sanity config');
@@ -110,8 +116,8 @@ crawl
 			return;
 		}
 
-		if (teams.length > 1 && options.tableUrl) {
-			log.error('--table-url cannot be combined with multiple --team values');
+		if (options.tableUrl && teams.length !== 1) {
+			log.error({ teamCount: teams.length }, '--table-url requires exactly one --team');
 			process.exit(1);
 		}
 
@@ -130,6 +136,12 @@ crawl
 		if (filtered.length === 0) {
 			log.error({ slugs: teams }, 'no matching teams with tableUrl found in Sanity config');
 			process.exit(1);
+		}
+
+		if (teams.length > 0 && filtered.length < teams.length) {
+			const matched = new Set(filtered.map((t) => t.slug));
+			const missing = teams.filter((slug) => !matched.has(slug));
+			log.warn({ missing }, 'some --team slugs did not match any Sanity team');
 		}
 
 		log.info({ count: filtered.length }, 'crawling tables for teams from Sanity config');

--- a/bin/wsc.ts
+++ b/bin/wsc.ts
@@ -35,10 +35,7 @@ crawl
 		(val: string, prev: string[]) => [...prev, val],
 		[] as string[]
 	)
-	.option(
-		'-l, --league <name>',
-		'League name for manual mode (requires exactly one --team)'
-	)
+	.option('-l, --league <name>', 'League name for manual mode (requires exactly one --team)')
 	.option('-s, --season <year>', 'Season year', new Date().getFullYear().toString())
 	.option('-c, --competition <id>', 'Competition ID', 'FFV')
 	.action(
@@ -47,12 +44,14 @@ crawl
 
 			// Manual mode: single team with explicit league
 			if (teams.length === 1 && options.league) {
-				await crawlFixtures([{
-					team: teams[0],
-					league: options.league,
-					season: options.season,
-					competition: options.competition,
-				}]);
+				await crawlFixtures([
+					{
+						team: teams[0],
+						league: options.league,
+						season: options.season,
+						competition: options.competition
+					}
+				]);
 				return;
 			}
 
@@ -68,9 +67,8 @@ crawl
 				process.exit(1);
 			}
 
-			const filtered = teams.length > 0
-				? sanityTeams.filter((t) => teams.includes(t.slug))
-				: sanityTeams;
+			const filtered =
+				teams.length > 0 ? sanityTeams.filter((t) => teams.includes(t.slug)) : sanityTeams;
 
 			if (filtered.length === 0) {
 				log.error({ slugs: teams }, 'no matching teams found in Sanity config');
@@ -84,7 +82,7 @@ crawl
 					team: t.slug,
 					league: t.leagueName,
 					season: options.season,
-					competition: t.competitionName?.trim() || options.competition,
+					competition: t.competitionName?.trim() || options.competition
 				}))
 			);
 		}
@@ -99,7 +97,10 @@ crawl
 		(val: string, prev: string[]) => [...prev, val],
 		[] as string[]
 	)
-	.option('-u, --table-url <url>', 'Dribl ladder page URL for manual mode (requires exactly one --team)')
+	.option(
+		'-u, --table-url <url>',
+		'Dribl ladder page URL for manual mode (requires exactly one --team)'
+	)
 	.action(async (options: { team: string[]; tableUrl?: string }) => {
 		const teams = options.team;
 
@@ -123,9 +124,8 @@ crawl
 			process.exit(1);
 		}
 
-		const filtered = teams.length > 0
-			? teamsWithTable.filter((t) => teams.includes(t.slug))
-			: teamsWithTable;
+		const filtered =
+			teams.length > 0 ? teamsWithTable.filter((t) => teams.includes(t.slug)) : teamsWithTable;
 
 		if (filtered.length === 0) {
 			log.error({ slugs: teams }, 'no matching teams with tableUrl found in Sanity config');

--- a/bin/wsc.ts
+++ b/bin/wsc.ts
@@ -31,62 +31,62 @@ crawl
 	.description('Extract fixtures data from Dribl with filtering')
 	.option(
 		'-t, --team <slug>',
-		'Team slug for output folder (e.g., "state-league-2-men-s-north-west")'
+		'Team slug (repeatable; omit to crawl all Sanity teams)',
+		(val: string, prev: string[]) => [...prev, val],
+		[] as string[]
 	)
 	.option(
-		'-l, --league <slug>',
-		'League slug for filtering (e.g., "State League 2 Men\'s - North-West")'
+		'-l, --league <name>',
+		'League name for manual mode (requires exactly one --team)'
 	)
 	.option('-s, --season <year>', 'Season year', new Date().getFullYear().toString())
 	.option('-c, --competition <id>', 'Competition ID', 'FFV')
 	.action(
-		async (options: { team?: string; league?: string; season?: string; competition?: string }) => {
-			if (options.team && options.league) {
-				await crawlFixtures({
-					team: options.team,
+		async (options: { team: string[]; league?: string; season?: string; competition?: string }) => {
+			const teams = options.team;
+
+			// Manual mode: single team with explicit league
+			if (teams.length === 1 && options.league) {
+				await crawlFixtures([{
+					team: teams[0],
 					league: options.league,
 					season: options.season,
-					competition: options.competition
-				});
+					competition: options.competition,
+				}]);
 				return;
 			}
 
-			if (options.team || options.league) {
-				log.error(
-					'both --team and --league must be provided together, or omit both to use Sanity config'
-				);
+			if (teams.length > 1 && options.league) {
+				log.error('--league cannot be combined with multiple --team values');
 				process.exit(1);
 			}
 
-			const teams = await getCrawlableTeams();
-			if (teams.length === 0) {
+			// Sanity mode: load all crawlable teams, optionally filter by slug
+			const sanityTeams = await getCrawlableTeams();
+			if (sanityTeams.length === 0) {
 				log.error('no teams with enableFixturesCrawler found in Sanity');
 				process.exit(1);
 			}
 
-			log.info({ count: teams.length }, 'crawling fixtures for teams from Sanity config');
-			const failures: string[] = [];
+			const filtered = teams.length > 0
+				? sanityTeams.filter((t) => teams.includes(t.slug))
+				: sanityTeams;
 
-			for (const team of teams) {
-				try {
-					log.info({ team: team.slug }, 'crawling team');
-					const competition = team.competitionName?.trim() || options.competition;
-					await crawlFixtures({
-						team: team.slug,
-						league: team.leagueName,
-						season: options.season,
-						competition
-					});
-				} catch {
-					// crawlFixtures already logs errors; collect failures for summary
-					failures.push(team.slug);
-				}
-			}
-
-			if (failures.length > 0) {
-				log.error({ failures }, 'crawl failed for some teams');
+			if (filtered.length === 0) {
+				log.error({ slugs: teams }, 'no matching teams found in Sanity config');
 				process.exit(1);
 			}
+
+			log.info({ count: filtered.length }, 'crawling fixtures for teams from Sanity config');
+
+			await crawlFixtures(
+				filtered.map((t) => ({
+					team: t.slug,
+					league: t.leagueName,
+					season: options.season,
+					competition: t.competitionName?.trim() || options.competition,
+				}))
+			);
 		}
 	);
 
@@ -95,46 +95,46 @@ crawl
 	.description('Extract league table data from Dribl')
 	.option(
 		'-t, --team <slug>',
-		'Team slug for output filename (e.g., "state-league-2-men-s-north-west")'
+		'Team slug (repeatable; omit to crawl all Sanity teams with a tableUrl)',
+		(val: string, prev: string[]) => [...prev, val],
+		[] as string[]
 	)
-	.option('-u, --table-url <url>', 'Dribl ladder page URL for the team')
-	.action(async (options: { team?: string; tableUrl?: string }) => {
-		if (options.team && options.tableUrl) {
-			await crawlTable({ team: options.team, tableUrl: options.tableUrl });
+	.option('-u, --table-url <url>', 'Dribl ladder page URL for manual mode (requires exactly one --team)')
+	.action(async (options: { team: string[]; tableUrl?: string }) => {
+		const teams = options.team;
+
+		// Manual mode: single team with explicit table URL
+		if (teams.length === 1 && options.tableUrl) {
+			await crawlTable([{ team: teams[0], tableUrl: options.tableUrl }]);
 			return;
 		}
 
-		if (options.team || options.tableUrl) {
-			log.error(
-				'both --team and --table-url must be provided together, or omit both to use Sanity config'
-			);
+		if (teams.length > 1 && options.tableUrl) {
+			log.error('--table-url cannot be combined with multiple --team values');
 			process.exit(1);
 		}
 
-		const teams = await getCrawlableTeams();
-		const teamsWithTable = teams.filter((t) => t.tableUrl);
+		// Sanity mode: load all teams with tableUrl, optionally filter by slug
+		const sanityTeams = await getCrawlableTeams();
+		const teamsWithTable = sanityTeams.filter((t) => t.tableUrl);
 
 		if (teamsWithTable.length === 0) {
 			log.error('no teams with tableUrl found in Sanity');
 			process.exit(1);
 		}
 
-		log.info({ count: teamsWithTable.length }, 'crawling tables for teams from Sanity config');
-		const failures: string[] = [];
+		const filtered = teams.length > 0
+			? teamsWithTable.filter((t) => teams.includes(t.slug))
+			: teamsWithTable;
 
-		for (const team of teamsWithTable) {
-			try {
-				log.info({ team: team.slug }, 'crawling team');
-				await crawlTable({ team: team.slug, tableUrl: team.tableUrl! });
-			} catch {
-				failures.push(team.slug);
-			}
-		}
-
-		if (failures.length > 0) {
-			log.error({ failures }, 'crawl failed for some teams');
+		if (filtered.length === 0) {
+			log.error({ slugs: teams }, 'no matching teams with tableUrl found in Sanity config');
 			process.exit(1);
 		}
+
+		log.info({ count: filtered.length }, 'crawling tables for teams from Sanity config');
+
+		await crawlTable(filtered.map((t) => ({ team: t.slug, tableUrl: t.tableUrl! })));
 	});
 
 sync


### PR DESCRIPTION
## Summary

Refactored the fixtures and table crawlers to process multiple teams in a single browser session, improving performance and resource efficiency. Updated the CLI to support both manual mode (single team with explicit parameters) and Sanity mode (batch processing with optional filtering).

## Key Changes

- **Batch processing**: `crawlFixtures()` and `crawlTable()` now accept arrays of team configurations instead of single teams, enabling a single browser session to crawl all teams sequentially
- **CLI improvements**: 
  - `-t, --team` is now repeatable (collector function) to filter which teams to crawl
  - Manual mode requires exactly one `-t` plus the URL/league option
  - Sanity mode (no manual options) fetches all crawlable teams from CMS and optionally filters by slug
- **Error handling**: Per-team failures are collected and the session continues to the next team; a single error is thrown at the end with all failed team slugs
- **Documentation**: Updated SKILL.md with new patterns, CLI examples, and best practices for single-browser-session architecture
- **Code organization**: Extracted `logTeamError()` helper function for consistent error logging across crawlers
- **Type naming**: Renamed `CrawlFixturesOptions` → `CrawlFixturesTeamOptions` and `CrawlTableOptions` → `CrawlTableTeamOptions` to clarify they represent a single team's configuration

## Implementation Details

- Browser launches once per crawl command and reuses the same page instance for all teams
- Responses array is reset between fixtures and results crawling for each team
- CLI validation ensures manual mode has exactly one team and Sanity mode filters correctly
- All file paths and output directories remain unchanged; only the processing flow is refactored
- CI integration simplified: no team args needed in GitHub Actions—all Sanity teams are crawled in one session

https://claude.ai/code/session_013PQMdpAmQFtkDBPefDzuy6

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * CLI commands now support repeatable team selection (`-t` flag) to crawl multiple teams in a single batch operation.
  * Batch processing mode processes all teams in one session and reports aggregated results at completion.

* **Improvements**
  * Enhanced error handling with clearer diagnostic messages for setup issues.
  * Sanity mode now filters teams based on provided selections before batch processing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->