### PR TITLE
fix: sync table only warn and continue

### DIFF
--- a/bin/commands/syncTable.ts
+++ b/bin/commands/syncTable.ts
@@ -56,6 +56,14 @@ export async function syncTable({ team }: SyncTableOptions) {
 
 	try {
 		const inputPath = path.join(externalTableDir, `${team}.json`);
+
+		try {
+			await fs.access(inputPath);
+		} catch {
+			log.warn({ team }, 'no external table data found, skipping');
+			return;
+		}
+
 		const content = await fs.readFile(inputPath, 'utf-8');
 		const external = externalTableApiResponseSchema.parse(JSON.parse(content));
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the sync table operation with file validation. The system now checks that external table data is accessible before attempting to process it. Missing or inaccessible files trigger a warning message and graceful exit, preventing downstream errors and improving system stability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->