### PR TITLE
fix: remove date badge from hero carousel and clarify article publish date

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17395,6 +17395,7 @@
 			"cpu": [
 				"arm64"
 			],
+			"dev": true,
 			"license": "MPL-2.0",
 			"optional": true,
 			"os": [
@@ -17415,6 +17416,7 @@
 			"cpu": [
 				"arm64"
 			],
+			"dev": true,
 			"license": "MPL-2.0",
 			"optional": true,
 			"os": [
@@ -17435,6 +17437,7 @@
 			"cpu": [
 				"x64"
 			],
+			"dev": true,
 			"license": "MPL-2.0",
 			"optional": true,
 			"os": [
@@ -17455,6 +17458,7 @@
 			"cpu": [
 				"x64"
 			],
+			"dev": true,
 			"license": "MPL-2.0",
 			"optional": true,
 			"os": [
@@ -17475,6 +17479,7 @@
 			"cpu": [
 				"arm"
 			],
+			"dev": true,
 			"license": "MPL-2.0",
 			"optional": true,
 			"os": [
@@ -17495,6 +17500,7 @@
 			"cpu": [
 				"arm64"
 			],
+			"dev": true,
 			"license": "MPL-2.0",
 			"optional": true,
 			"os": [
@@ -17515,6 +17521,7 @@
 			"cpu": [
 				"arm64"
 			],
+			"dev": true,
 			"license": "MPL-2.0",
 			"optional": true,
 			"os": [
@@ -17535,6 +17542,7 @@
 			"cpu": [
 				"x64"
 			],
+			"dev": true,
 			"license": "MPL-2.0",
 			"optional": true,
 			"os": [
@@ -17555,6 +17563,7 @@
 			"cpu": [
 				"x64"
 			],
+			"dev": true,
 			"license": "MPL-2.0",
 			"optional": true,
 			"os": [
@@ -17575,6 +17584,7 @@
 			"cpu": [
 				"arm64"
 			],
+			"dev": true,
 			"license": "MPL-2.0",
 			"optional": true,
 			"os": [
@@ -17595,6 +17605,7 @@
 			"cpu": [
 				"x64"
 			],
+			"dev": true,
 			"license": "MPL-2.0",
 			"optional": true,
 			"os": [

--- a/src/app/(site)/news/[slug]/page.tsx
+++ b/src/app/(site)/news/[slug]/page.tsx
@@ -115,7 +115,7 @@ export default async function ArticlePage({ params }: ArticlePageProps) {
 				<div className="mb-8">
 					<h1 className="mb-4 text-3xl font-bold lg:text-4xl">{article.title}</h1>
 					<time dateTime={publishedDate.toISOString()} className="text-base-content/60 text-lg">
-						{formattedDate}
+						Published at: {formattedDate}
 					</time>
 					<div className="mt-4">
 						<ShareButton title={article.title} url={articleUrl} />

--- a/src/app/(site)/news/[slug]/page.tsx
+++ b/src/app/(site)/news/[slug]/page.tsx
@@ -115,7 +115,7 @@ export default async function ArticlePage({ params }: ArticlePageProps) {
 				<div className="mb-8">
 					<h1 className="mb-4 text-3xl font-bold lg:text-4xl">{article.title}</h1>
 					<time dateTime={publishedDate.toISOString()} className="text-base-content/60 text-lg">
-						Published at: {formattedDate}
+						Published {formattedDate}
 					</time>
 					<div className="mt-4">
 						<ShareButton title={article.title} url={articleUrl} />

--- a/src/components/home/HeroCarousel.tsx
+++ b/src/components/home/HeroCarousel.tsx
@@ -93,14 +93,6 @@ export function HeroCarousel({
 		return null;
 	}
 
-	const formatDate = (date: string) => {
-		return new Date(date).toLocaleDateString('en-AU', {
-			month: 'short',
-			day: 'numeric',
-			year: 'numeric'
-		});
-	};
-
 	return (
 		<section
 			className="group relative w-full"
@@ -155,12 +147,6 @@ export function HeroCarousel({
 							/>
 							<div className="absolute inset-0 bg-linear-to-t from-black/80 via-black/30 to-transparent" />
 							<div className="absolute inset-0 flex flex-col-reverse justify-between p-6 md:flex-col md:p-10">
-								<div className="flex justify-start">
-									<div className="badge badge-primary badge-lg bg-primary/90 gap-2 px-4 py-3 font-semibold backdrop-blur-sm">
-										{formatDate(article.publishedAt)}
-									</div>
-								</div>
-
 								<div className="max-w-4xl sm:px-0">
 									<h2
 										className={clsx(


### PR DESCRIPTION
Removes the date badge from the home page hero carousel to avoid
conflicting with event dates displayed within the hero images.
Adds "Published at:" prefix to the article page date for clarity.

https://claude.ai/code/session_01Cv81Hx4dsMioSA3f6ynMx5

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Added "Published at:" label to news article publication dates for clarity
  * Removed publication date display from article carousel for a simplified view

<!-- end of auto-generated comment: release notes by coderabbit.ai -->