### PR TITLE
feat: split junior teams into separate boys and girls categories

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17395,6 +17395,7 @@
 			"cpu": [
 				"arm64"
 			],
+			"dev": true,
 			"license": "MPL-2.0",
 			"optional": true,
 			"os": [
@@ -17415,6 +17416,7 @@
 			"cpu": [
 				"arm64"
 			],
+			"dev": true,
 			"license": "MPL-2.0",
 			"optional": true,
 			"os": [
@@ -17435,6 +17437,7 @@
 			"cpu": [
 				"x64"
 			],
+			"dev": true,
 			"license": "MPL-2.0",
 			"optional": true,
 			"os": [
@@ -17455,6 +17458,7 @@
 			"cpu": [
 				"x64"
 			],
+			"dev": true,
 			"license": "MPL-2.0",
 			"optional": true,
 			"os": [
@@ -17475,6 +17479,7 @@
 			"cpu": [
 				"arm"
 			],
+			"dev": true,
 			"license": "MPL-2.0",
 			"optional": true,
 			"os": [
@@ -17495,6 +17500,7 @@
 			"cpu": [
 				"arm64"
 			],
+			"dev": true,
 			"license": "MPL-2.0",
 			"optional": true,
 			"os": [
@@ -17515,6 +17521,7 @@
 			"cpu": [
 				"arm64"
 			],
+			"dev": true,
 			"license": "MPL-2.0",
 			"optional": true,
 			"os": [
@@ -17535,6 +17542,7 @@
 			"cpu": [
 				"x64"
 			],
+			"dev": true,
 			"license": "MPL-2.0",
 			"optional": true,
 			"os": [
@@ -17555,6 +17563,7 @@
 			"cpu": [
 				"x64"
 			],
+			"dev": true,
 			"license": "MPL-2.0",
 			"optional": true,
 			"os": [
@@ -17575,6 +17584,7 @@
 			"cpu": [
 				"arm64"
 			],
+			"dev": true,
 			"license": "MPL-2.0",
 			"optional": true,
 			"os": [
@@ -17595,6 +17605,7 @@
 			"cpu": [
 				"x64"
 			],
+			"dev": true,
 			"license": "MPL-2.0",
 			"optional": true,
 			"os": [

--- a/src/components/teams/TeamsDirectory.tsx
+++ b/src/components/teams/TeamsDirectory.tsx
@@ -14,8 +14,8 @@ type GroupConfig = {
 const groupConfigs: GroupConfig[] = [
 	{ key: 'seniors', label: 'Seniors' },
 	{ key: 'reserves', label: 'Reserves' },
-	{ key: 'juniorBoys', label: 'Junior Boys' },
 	{ key: 'juniorGirls', label: 'Junior Girls' },
+	{ key: 'juniorBoys', label: 'Junior Boys' },
 	{ key: 'masters', label: 'Masters' },
 	{ key: 'metros', label: 'Metros' }
 ];

--- a/src/components/teams/TeamsDirectory.tsx
+++ b/src/components/teams/TeamsDirectory.tsx
@@ -14,7 +14,8 @@ type GroupConfig = {
 const groupConfigs: GroupConfig[] = [
 	{ key: 'seniors', label: 'Seniors' },
 	{ key: 'reserves', label: 'Reserves' },
-	{ key: 'juniors', label: 'Juniors' },
+	{ key: 'juniorBoys', label: 'Junior Boys' },
+	{ key: 'juniorGirls', label: 'Junior Girls' },
 	{ key: 'masters', label: 'Masters' },
 	{ key: 'metros', label: 'Metros' }
 ];

--- a/src/lib/content/teams.ts
+++ b/src/lib/content/teams.ts
@@ -7,6 +7,7 @@ export const teamsDirectoryQuery = groq`
     name,
     "slug": slug.current,
     ageGroup,
+    gender,
     order
   }
 `;

--- a/src/lib/teamService.ts
+++ b/src/lib/teamService.ts
@@ -16,12 +16,12 @@ const juniorAgeGroups: AgeGroup[] = [
 	'18'
 ];
 
-export function getTabCategory(ageGroup: AgeGroup): TabCategory {
+export function getTabCategory(ageGroup: AgeGroup, gender?: TeamBase['gender']): TabCategory {
 	if (ageGroup === 'seniors') return 'seniors';
 	if (ageGroup === 'reserves') return 'reserves';
 	if (ageGroup === 'metros') return 'metros';
 	if (ageGroup === 'masters' || ageGroup === 'over45') return 'masters';
-	return 'juniors';
+	return gender === 'female' ? 'juniorGirls' : 'juniorBoys';
 }
 
 export function sortTeams<T extends TeamBase>(teams: T[]): T[] {
@@ -46,20 +46,22 @@ export function groupTeamsByTab<T extends TeamBase>(teams: T[]): TeamsByTab<T> {
 	const grouped: TeamsByTab<T> = {
 		seniors: [],
 		reserves: [],
-		juniors: [],
+		juniorBoys: [],
+		juniorGirls: [],
 		masters: [],
 		metros: []
 	};
 
 	teams.forEach((team) => {
-		const category = getTabCategory(team.ageGroup);
+		const category = getTabCategory(team.ageGroup, team.gender);
 		grouped[category].push(team);
 	});
 
 	return {
 		seniors: sortTeams(grouped.seniors),
 		reserves: sortTeams(grouped.reserves),
-		juniors: sortTeams(grouped.juniors),
+		juniorBoys: sortTeams(grouped.juniorBoys),
+		juniorGirls: sortTeams(grouped.juniorGirls),
 		masters: sortTeams(grouped.masters),
 		metros: sortTeams(grouped.metros)
 	};

--- a/src/types/team.ts
+++ b/src/types/team.ts
@@ -5,6 +5,7 @@ export type TeamBase = {
 	name: string;
 	slug: string;
 	ageGroup: AgeGroup;
+	gender?: 'male' | 'female' | 'mixed';
 	order: number;
 };
 
@@ -28,7 +29,13 @@ export type AgeGroup =
 	| '17'
 	| '18';
 
-export type TabCategory = 'seniors' | 'reserves' | 'juniors' | 'masters' | 'metros';
+export type TabCategory =
+	| 'seniors'
+	| 'reserves'
+	| 'juniorBoys'
+	| 'juniorGirls'
+	| 'masters'
+	| 'metros';
 
 export type PersonPhoto = {
 	asset: {
@@ -90,7 +97,8 @@ export interface Team {
 export type TeamsByTab<T extends TeamBase = Team> = {
 	seniors: T[];
 	reserves: T[];
-	juniors: T[];
+	juniorBoys: T[];
+	juniorGirls: T[];
 	masters: T[];
 	metros: T[];
 };


### PR DESCRIPTION
## Summary
This PR separates junior teams into gender-specific categories (Junior Boys and Junior Girls) instead of a single "Juniors" category. This allows for better organization and display of junior teams based on gender.

## Key Changes
- Added optional `gender` field to `TeamBase` type to support gender classification ('male' | 'female' | 'mixed')
- Updated `getTabCategory()` function to accept gender parameter and return gender-specific junior categories
- Split `TabCategory` type to include `juniorBoys` and `juniorGirls` instead of generic `juniors`
- Updated `TeamsByTab` type to reflect separate junior boys and girls arrays
- Modified `groupTeamsByTab()` to pass gender information when categorizing teams
- Updated `TeamsDirectory` component to display "Junior Boys" and "Junior Girls" as separate sections
- Updated Sanity CMS query to fetch the new `gender` field

## Implementation Details
- The gender parameter in `getTabCategory()` is optional, defaulting to 'juniorBoys' for backward compatibility
- Teams are now categorized based on both age group and gender, enabling proper separation of junior teams
- The UI now displays two separate sections for junior teams instead of one combined section

https://claude.ai/code/session_01MLAptfSPT46LP6KdUUTgCt