### PR TITLE
feat: absorb table sync into sync fixtures

### DIFF
--- a/bin/commands/syncFixtures.ts
+++ b/bin/commands/syncFixtures.ts
@@ -10,6 +10,7 @@ import {
 	fixtureDataSchema
 } from '@/types/matches';
 import type { Fixture, FixtureData } from '@/types/matches';
+import { syncTable } from './syncTable';
 
 const log = logger.child({ module: 'sync-fixtures' });
 
@@ -219,6 +220,8 @@ export async function syncFixtures({ team }: SyncFixturesOptions) {
 
 		// Write to file
 		await writeFixtureData(team, fixtureData);
+
+		await syncTable({ team });
 
 		log.info('sync completed');
 	} catch (error) {


### PR DESCRIPTION
Since crawl:fixtures already captures ladder/table data per team,
sync:fixtures now also runs syncTable for each team so the pipeline
stays consistent without a separate sync step.

https://claude.ai/code/session_01XNg9CT4Ry9WxN9gM7mCcs4

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved fixture synchronization to ensure all data is properly synced and validated before completion.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->