### PR TITLE
fix: download chunk artifacts into data/ to restore correct path prefix

### DIFF
--- a/.github/workflows/crawl.yml
+++ b/.github/workflows/crawl.yml
@@ -121,7 +121,7 @@ jobs:
       - uses: actions/download-artifact@v4
         with:
           pattern: chunk-*
-          path: .
+          path: data/
           merge-multiple: true
       - name: Format code
         run: npm run format


### PR DESCRIPTION
## Summary
- `upload-artifact@v4` strips the longest common path prefix from uploaded files, so `data/matches/team.json` is stored as `matches/team.json` inside the artifact
- Downloading into `.` (repo root) caused files to land at `./matches/` and `./table/` instead of `./data/matches/` and `./data/table/`
- Fix: change `path: .` to `path: data/` on the `chunk-*` download step so the stripped prefix is restored on extraction

## Test plan
- [ ] Trigger `workflow_dispatch` on the crawl workflow
- [ ] Confirm the resulting `feat/update-clubs-and-fixtures` PR contains files only under `data/matches/` and `data/table/`
- [ ] Confirm no `matches/`, `table/`, or `clubs/` directories appear at repo root

🤖 Generated with [Claude Code](https://claude.com/claude-code)