### PR TITLE
feat: cache Playwright browsers in CI workflows

### DIFF
--- a/.github/workflows/crawl.yml
+++ b/.github/workflows/crawl.yml
@@ -46,6 +46,11 @@ jobs:
       - uses: jdx/mise-action@v4
       - name: Install dependencies
         run: npm ci
+      - name: Cache Playwright browsers
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/ms-playwright
+          key: playwright-chrome-${{ hashFiles('package-lock.json') }}
       - name: Install Chrome
         run: npx playwright install --with-deps chrome
       - name: Crawl clubs
@@ -71,6 +76,11 @@ jobs:
       - uses: jdx/mise-action@v4
       - name: Install dependencies
         run: npm ci
+      - name: Cache Playwright browsers
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/ms-playwright
+          key: playwright-chrome-${{ hashFiles('package-lock.json') }}
       - name: Install Chrome
         run: npx playwright install --with-deps chrome
 


### PR DESCRIPTION
## Summary
Added caching for Playwright browser binaries in the GitHub Actions workflows to improve CI performance and reduce installation time.

## Key Changes
- Added `actions/cache@v4` step to cache Playwright browsers at `~/.cache/ms-playwright` in both the "crawl clubs" and "crawl events" jobs
- Cache key is based on `package-lock.json` hash to invalidate when dependencies change
- Caching is applied before the `npx playwright install` step to speed up subsequent workflow runs

## Implementation Details
- The cache path `~/.cache/ms-playwright` is the default location where Playwright stores browser binaries
- Using `package-lock.json` as the cache key ensures the cache is invalidated when Playwright version or other dependencies are updated
- This optimization reduces CI run time by avoiding redundant browser downloads on every workflow execution

https://claude.ai/code/session_01EzeFxrP2WboHLTzTmnAEJF