### PR TITLE
fix: stage crawl chunk outputs before artifact upload

### DIFF
--- a/.github/workflows/crawl.yml
+++ b/.github/workflows/crawl.yml
@@ -89,21 +89,24 @@ jobs:
 
       - name: Sync fixtures and tables for chunk
         run: |
+          mkdir -p tmp/crawl/matches tmp/crawl/table
           for team in ${{ join(matrix.chunk, ' ') }}; do
             npx tsx bin/wsc.ts sync fixtures --team "$team"
             npx tsx bin/wsc.ts sync table --team "$team"
+            cp "data/matches/$team.json" "tmp/crawl/matches/$team.json"
+            cp "data/table/$team.json" "tmp/crawl/table/$team.json"
           done
 
       - uses: actions/upload-artifact@v4
         with:
           name: matches-chunk-${{ strategy.job-index }}
-          path: data/matches/
+          path: tmp/crawl/matches/
           if-no-files-found: warn
 
       - uses: actions/upload-artifact@v4
         with:
           name: table-chunk-${{ strategy.job-index }}
-          path: data/table/
+          path: tmp/crawl/table/
           if-no-files-found: warn
 
   commit:

--- a/.github/workflows/crawl.yml
+++ b/.github/workflows/crawl.yml
@@ -93,8 +93,17 @@ jobs:
           for team in ${{ join(matrix.chunk, ' ') }}; do
             npx tsx bin/wsc.ts sync fixtures --team "$team"
             npx tsx bin/wsc.ts sync table --team "$team"
-            cp "data/matches/$team.json" "tmp/crawl/matches/$team.json"
-            cp "data/table/$team.json" "tmp/crawl/table/$team.json"
+            if [[ -f "data/matches/$team.json" ]]; then
+              cp "data/matches/$team.json" "tmp/crawl/matches/$team.json"
+            else
+              echo "warn: missing matches file for team=$team"
+            fi
+
+            if [[ -f "data/table/$team.json" ]]; then
+              cp "data/table/$team.json" "tmp/crawl/table/$team.json"
+            else
+              echo "warn: missing table file for team=$team"
+            fi
           done
 
       - uses: actions/upload-artifact@v4


### PR DESCRIPTION
## Summary
- stage per-team crawl outputs into `tmp/crawl/matches` and `tmp/crawl/table` during each chunk job
- upload artifacts from staged temp directories instead of whole `data/matches` and `data/table` trees
- prevent merged artifact filename collisions that were corrupting JSON and causing `npm run format` to fail in the Create PR job

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Optimized CI/CD workflow data processing pipeline to improve efficiency during syncs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->