### PR TITLE
fix: increase mobile hero height and pad heading above carousel dots

### DIFF
--- a/src/app/(site)/page.tsx
+++ b/src/app/(site)/page.tsx
@@ -86,7 +86,9 @@ export default async function Home() {
 						<div className={clsx(generalNews.length > 0 ? 'lg:w-2/3' : 'lg:w-full')}>
 							<HeroCarousel
 								articles={carouselArticles}
-								className={generalNews.length === 0 ? 'h-[70vh]' : 'h-[55vh]'}
+								className={
+									generalNews.length === 0 ? 'h-[70vh] md:h-[70vh]' : 'h-[65vh] md:h-[55vh]'
+								}
 								isFullWidth={generalNews.length === 0}
 							/>
 						</div>

--- a/src/components/home/HeroCarousel.tsx
+++ b/src/components/home/HeroCarousel.tsx
@@ -146,7 +146,7 @@ export function HeroCarousel({
 								sizes={isFullWidth ? '100vw' : '67vw'}
 							/>
 							<div className="absolute inset-0 bg-linear-to-t from-black/80 via-black/30 to-transparent" />
-							<div className="absolute inset-0 flex flex-col-reverse justify-between p-6 md:flex-col md:p-10">
+							<div className="absolute inset-0 flex flex-col-reverse justify-between p-6 pb-16 md:flex-col md:p-10 md:pb-10">
 								<div className="max-w-4xl sm:px-0">
 									<h2
 										className={clsx(


### PR DESCRIPTION
Heading text and carousel dot indicators were colliding on mobile
because both occupied the same bottom area. Raising the hero to
65vh on mobile (vs 55vh on md+) and adding pb-16 to the content
overlay gives the heading room to sit clear of the dots.

https://claude.ai/code/session_01Ux9M3xdTUSyxGhfLH9u3DE