### PR TITLE
feat: use club name in fixtures and table, fall back to team name only when club has multiple entries in competition

### DIFF
--- a/src/components/teams/LeagueTable.tsx
+++ b/src/components/teams/LeagueTable.tsx
@@ -23,8 +23,21 @@ const columns: Column[] = [
 	{ label: 'Points', shortLabel: 'Pts', key: 'points' }
 ];
 
+function buildDuplicateClubNames(entries: TableEntry[]): Set<string> {
+	const counts = new Map<string, number>();
+	for (const entry of entries) {
+		counts.set(entry.clubName, (counts.get(entry.clubName) ?? 0) + 1);
+	}
+	return new Set([...counts.entries()].filter(([, count]) => count > 1).map(([name]) => name));
+}
+
+function resolveEntryDisplayName(entry: TableEntry, duplicateClubNames: Set<string>): string {
+	return duplicateClubNames.has(entry.clubName) ? entry.teamName : entry.clubName;
+}
+
 export function LeagueTable({ entries }: LeagueTableProps) {
 	const { wscClubDriblName } = getClubConfig();
+	const duplicateClubNames = buildDuplicateClubNames(entries);
 
 	return (
 		<div className="overflow-x-auto">
@@ -60,7 +73,9 @@ export function LeagueTable({ entries }: LeagueTableProps) {
 											className="shrink-0 rounded-full object-contain"
 											unoptimized
 										/>
-										<span className="truncate">{entry.teamName}</span>
+										<span className="truncate">
+											{resolveEntryDisplayName(entry, duplicateClubNames)}
+										</span>
 									</div>
 								</td>
 								{columns.map((col) => (

--- a/src/lib/clubService.ts
+++ b/src/lib/clubService.ts
@@ -47,9 +47,12 @@ export function findClubExternalId(teamName: string, logoUrl: string): string {
 	throw new Error(`Could not find club for team: ${teamName} (logo: ${logoUrl})`);
 }
 
-export function resolveTeamDisplayName(teamName: string | undefined, club: Club): string {
-	if (!teamName) return club.displayName;
-	if (normalizeTeamName(teamName) !== teamName.trim()) return club.displayName;
+export function resolveTeamDisplayName(
+	teamName: string | undefined,
+	club: Club,
+	hasDuplicates = false
+): string {
+	if (!teamName || !hasDuplicates) return club.displayName;
 	return teamName;
 }
 

--- a/src/lib/matches/matchService.ts
+++ b/src/lib/matches/matchService.ts
@@ -33,35 +33,70 @@ function isByeFixture(fixture: Fixture): boolean {
 	return fixture.homeTeamId === 'bye' || fixture.awayTeamId === 'bye';
 }
 
+function findDuplicateClubIds(fixtures: Fixture[]): Set<string> {
+	const clubTeamNames = new Map<string, Set<string>>();
+
+	for (const fixture of fixtures) {
+		if (isByeFixture(fixture)) continue;
+
+		const sides: Array<[string, string | undefined]> = [
+			[fixture.homeTeamId, fixture.homeTeamName],
+			[fixture.awayTeamId, fixture.awayTeamName]
+		];
+
+		for (const [clubId, teamName] of sides) {
+			if (!clubTeamNames.has(clubId)) clubTeamNames.set(clubId, new Set());
+			if (teamName) clubTeamNames.get(clubId)!.add(teamName);
+		}
+	}
+
+	const duplicates = new Set<string>();
+	for (const [clubId, names] of clubTeamNames) {
+		if (names.size > 1) duplicates.add(clubId);
+	}
+	return duplicates;
+}
+
+function enrichFixture(fixture: Fixture, duplicateClubIds: Set<string>): EnrichedFixture {
+	const homeTeam = getClubByExternalId(fixture.homeTeamId);
+	const awayTeam = getClubByExternalId(fixture.awayTeamId);
+
+	if (!homeTeam || !awayTeam) {
+		throw new Error(`Club not found for fixture round ${fixture.round}`);
+	}
+
+	return {
+		round: fixture.round,
+		date: fixture.date,
+		day: fixture.day,
+		time: fixture.time,
+		homeTeam,
+		awayTeam,
+		homeTeamDisplayName: resolveTeamDisplayName(
+			fixture.homeTeamName,
+			homeTeam,
+			duplicateClubIds.has(fixture.homeTeamId)
+		),
+		awayTeamDisplayName: resolveTeamDisplayName(
+			fixture.awayTeamName,
+			awayTeam,
+			duplicateClubIds.has(fixture.awayTeamId)
+		),
+		address: fixture.address,
+		coordinates: fixture.coordinates,
+		homeScore: fixture.homeScore,
+		awayScore: fixture.awayScore,
+		homeScoreHalf: fixture.homeScoreHalf,
+		awayScoreHalf: fixture.awayScoreHalf,
+		status: fixture.status
+	};
+}
+
 function enrichFixtures(fixtures: Fixture[]): EnrichedFixture[] {
+	const duplicateClubIds = findDuplicateClubIds(fixtures);
 	return fixtures
 		.filter((f) => !isByeFixture(f))
-		.map((fixture) => {
-			const homeTeam = getClubByExternalId(fixture.homeTeamId);
-			const awayTeam = getClubByExternalId(fixture.awayTeamId);
-
-			if (!homeTeam || !awayTeam) {
-				throw new Error(`Club not found for fixture round ${fixture.round}`);
-			}
-
-			return {
-				round: fixture.round,
-				date: fixture.date,
-				day: fixture.day,
-				time: fixture.time,
-				homeTeam,
-				awayTeam,
-				homeTeamDisplayName: resolveTeamDisplayName(fixture.homeTeamName, homeTeam),
-				awayTeamDisplayName: resolveTeamDisplayName(fixture.awayTeamName, awayTeam),
-				address: fixture.address,
-				coordinates: fixture.coordinates,
-				homeScore: fixture.homeScore,
-				awayScore: fixture.awayScore,
-				homeScoreHalf: fixture.homeScoreHalf,
-				awayScoreHalf: fixture.awayScoreHalf,
-				status: fixture.status
-			};
-		});
+		.map((fixture) => enrichFixture(fixture, duplicateClubIds));
 }
 
 const loadFixture = cache(async function loadFixture(
@@ -105,6 +140,7 @@ const matchDurationMinutes = 120;
 
 function resolveNextMatch(fixtures: Fixture[], wscClubDriblId: string): EnrichedFixture | null {
 	const now = new Date();
+	const duplicateClubIds = findDuplicateClubIds(fixtures);
 
 	const upcoming = fixtures
 		.filter((f) => !isByeFixture(f))
@@ -122,11 +158,12 @@ function resolveNextMatch(fixtures: Fixture[], wscClubDriblId: string): Enriched
 	if (upcoming.length === 0) return null;
 
 	upcoming.sort((a, b) => a.matchDateTime.getTime() - b.matchDateTime.getTime());
-	return enrichFixtures([upcoming[0].fixture])[0];
+	return enrichFixture(upcoming[0].fixture, duplicateClubIds);
 }
 
 function resolvePreviousMatch(fixtures: Fixture[], wscClubDriblId: string): EnrichedFixture | null {
 	const now = new Date();
+	const duplicateClubIds = findDuplicateClubIds(fixtures);
 
 	const completed = fixtures
 		.filter((f) => !isByeFixture(f))
@@ -144,7 +181,7 @@ function resolvePreviousMatch(fixtures: Fixture[], wscClubDriblId: string): Enri
 	if (completed.length === 0) return null;
 
 	completed.sort((a, b) => b.matchDateTime.getTime() - a.matchDateTime.getTime());
-	return enrichFixtures([completed[0].fixture])[0];
+	return enrichFixture(completed[0].fixture, duplicateClubIds);
 }
 
 export async function getTeamMatches(teamSlug: string): Promise<{


### PR DESCRIPTION
- resolveTeamDisplayName now accepts hasDuplicates flag; always shows club.displayName unless the club has multiple teams in the competition
- enrichFixtures scans all fixtures to detect clubs with >1 team (duplicate club IDs), then passes that context per-fixture
- Single-fixture enrichment extracted to enrichFixture() so resolveNextMatch/resolvePreviousMatch retain full competition duplicate context
- LeagueTable computes duplicate club names from entries and shows clubName for unique clubs, teamName for duplicated clubs

https://claude.ai/code/session_019YqECEj4QnxBW5mrcpdKZe

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved team name display in league tables and match listings to intelligently handle duplicate club names. When a club name appears multiple times, the system now displays the team name for clarity instead of the generic club name.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->