### PR TITLE
Filter browser extension noise from Sentry

### DIFF
--- a/src/instrumentation-client.ts
+++ b/src/instrumentation-client.ts
@@ -6,7 +6,11 @@ Sentry.init({
 	tracesSampleRate: 1,
 	debug: false,
 	enabled: isSentryEnabled(),
-	enableLogs: true
+	enableLogs: true,
+	ignoreErrors: [
+		// Browser extension noise — not application errors
+		'Invalid call to runtime.sendMessage()'
+	]
 });
 
 export const onRouterTransitionStart = Sentry.captureRouterTransitionStart;


### PR DESCRIPTION
Ignore 'Invalid call to runtime.sendMessage()' errors which originate from browser extensions, not application code.

https://claude.ai/code/session_01E5rNuzxr66BZHWSJtackXU

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved error monitoring by configuring filters to exclude irrelevant browser extension-related errors from tracking, enhancing the quality of error reporting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->