### PR TITLE
feat: add iCal calendar download for team fixtures

### DIFF
--- a/src/app/api/calendar/[slug]/route.ts
+++ b/src/app/api/calendar/[slug]/route.ts
@@ -11,6 +11,14 @@ type RouteParams = {
 	params: Promise<{ slug: string }>;
 };
 
+function escapeText(value: string): string {
+	return value
+		.replace(/\\/g, '\\\\')
+		.replace(/;/g, '\\;')
+		.replace(/,/g, '\\,')
+		.replace(/\n/g, '\\n');
+}
+
 function buildVEvent(fixture: EnrichedFixture, slug: string): string {
 	const [year, month, day] = fixture.date.split('-').map(Number);
 	const [hour, minute] = fixture.time.split(':').map(Number);
@@ -25,9 +33,11 @@ function buildVEvent(fixture: EnrichedFixture, slug: string): string {
 			.replace(/\.\d{3}Z$/, 'Z');
 
 	const uid = `r${fixture.round}-${fixture.homeTeam.externalId}-${fixture.awayTeam.externalId}-${slug}@williamstownsc.com.au`;
-	const summary = `${fixture.homeTeamDisplayName} vs ${fixture.awayTeamDisplayName} - Round ${fixture.round}`;
+	const summary = escapeText(
+		`${fixture.homeTeamDisplayName} vs ${fixture.awayTeamDisplayName} - Round ${fixture.round}`
+	);
 	const mapsUrl = fixture.coordinates ? `https://maps.google.com/?q=${fixture.coordinates}` : '';
-	const description = [fixture.address, mapsUrl].filter(Boolean).join('\\n');
+	const description = [escapeText(fixture.address), mapsUrl].filter(Boolean).join('\\n');
 	const status = fixture.status === 'complete' ? 'CONFIRMED' : 'TENTATIVE';
 
 	return [
@@ -36,7 +46,7 @@ function buildVEvent(fixture: EnrichedFixture, slug: string): string {
 		`DTSTART:${format(startUtc)}`,
 		`DTEND:${format(endUtc)}`,
 		`SUMMARY:${summary}`,
-		`LOCATION:${fixture.address}`,
+		`LOCATION:${escapeText(fixture.address)}`,
 		`DESCRIPTION:${description}`,
 		`STATUS:${status}`,
 		'END:VEVENT'

--- a/src/app/api/calendar/[slug]/route.ts
+++ b/src/app/api/calendar/[slug]/route.ts
@@ -1,0 +1,81 @@
+import { TZDate } from '@date-fns/tz';
+import { addHours } from 'date-fns';
+import { getFixturesForTeam } from '@/lib/matches/matchService';
+import type { EnrichedFixture } from '@/types/matches';
+
+const melbourneTimezone = 'Australia/Melbourne';
+const matchDurationHours = 2;
+
+type RouteParams = {
+	params: Promise<{ slug: string }>;
+};
+
+function buildVEvent(fixture: EnrichedFixture, slug: string): string {
+	const [year, month, day] = fixture.date.split('-').map(Number);
+	const [hour, minute] = fixture.time.split(':').map(Number);
+	const startTz = new TZDate(year, month - 1, day, hour, minute, melbourneTimezone);
+	const startUtc = new Date(startTz.getTime());
+	const endUtc = addHours(startUtc, matchDurationHours);
+
+	const format = (d: Date) =>
+		d
+			.toISOString()
+			.replace(/[-:]/g, '')
+			.replace(/\.\d{3}Z$/, 'Z');
+
+	const uid = `r${fixture.round}-${fixture.homeTeam.externalId}-${fixture.awayTeam.externalId}-${slug}@williamstownsc.com.au`;
+	const summary = `${fixture.homeTeamDisplayName} vs ${fixture.awayTeamDisplayName} - Round ${fixture.round}`;
+	const mapsUrl = fixture.coordinates ? `https://maps.google.com/?q=${fixture.coordinates}` : '';
+	const description = [fixture.address, mapsUrl].filter(Boolean).join('\\n');
+	const status = fixture.status === 'complete' ? 'CONFIRMED' : 'TENTATIVE';
+
+	return [
+		'BEGIN:VEVENT',
+		`UID:${uid}`,
+		`DTSTART:${format(startUtc)}`,
+		`DTEND:${format(endUtc)}`,
+		`SUMMARY:${summary}`,
+		`LOCATION:${fixture.address}`,
+		`DESCRIPTION:${description}`,
+		`STATUS:${status}`,
+		'END:VEVENT'
+	].join('\r\n');
+}
+
+function buildIcal(
+	fixtures: EnrichedFixture[],
+	competition: string,
+	season: number,
+	slug: string
+): string {
+	const events = fixtures.map((f) => buildVEvent(f, slug)).join('\r\n');
+	return [
+		'BEGIN:VCALENDAR',
+		'VERSION:2.0',
+		'PRODID:-//Williamstown SC//Fixtures//EN',
+		'CALSCALE:GREGORIAN',
+		'METHOD:PUBLISH',
+		`X-WR-CALNAME:${competition} ${season}`,
+		'X-WR-TIMEZONE:Australia/Melbourne',
+		events,
+		'END:VCALENDAR'
+	].join('\r\n');
+}
+
+export async function GET(_request: Request, { params }: RouteParams) {
+	const { slug } = await params;
+	const fixtureData = await getFixturesForTeam(slug);
+
+	if (!fixtureData) {
+		return new Response('Not Found', { status: 404 });
+	}
+
+	const ical = buildIcal(fixtureData.fixtures, fixtureData.competition, fixtureData.season, slug);
+
+	return new Response(ical, {
+		headers: {
+			'Content-Type': 'text/calendar; charset=utf-8',
+			'Content-Disposition': `attachment; filename="${slug}-fixtures.ics"`
+		}
+	});
+}

--- a/src/app/api/calendar/[slug]/route.ts
+++ b/src/app/api/calendar/[slug]/route.ts
@@ -1,5 +1,6 @@
 import { TZDate } from '@date-fns/tz';
 import { addHours } from 'date-fns';
+import { getClubConfig } from '@/lib/config';
 import { getFixturesForTeam } from '@/lib/matches/matchService';
 import type { EnrichedFixture } from '@/types/matches';
 
@@ -70,7 +71,12 @@ export async function GET(_request: Request, { params }: RouteParams) {
 		return new Response('Not Found', { status: 404 });
 	}
 
-	const ical = buildIcal(fixtureData.fixtures, fixtureData.competition, fixtureData.season, slug);
+	const { wscClubDriblId } = getClubConfig();
+	const wscFixtures = fixtureData.fixtures.filter(
+		(f) => f.homeTeam.externalId === wscClubDriblId || f.awayTeam.externalId === wscClubDriblId
+	);
+
+	const ical = buildIcal(wscFixtures, fixtureData.competition, fixtureData.season, slug);
 
 	return new Response(ical, {
 		headers: {

--- a/src/components/teams/TeamDetailNav.tsx
+++ b/src/components/teams/TeamDetailNav.tsx
@@ -3,7 +3,7 @@
 import Link from 'next/link';
 import { usePathname } from 'next/navigation';
 import { useEffect, useRef, useState } from 'react';
-import { ExternalLink, LayoutList } from 'lucide-react';
+import { CalendarArrowDown, ExternalLink, LayoutList } from 'lucide-react';
 
 type Tab = {
 	label: string;
@@ -135,6 +135,19 @@ export function TeamDetailNav({
 							</li>
 						);
 					})}
+					{hasFixtures && (
+						<li>
+							<a
+								href={`/api/calendar/${teamSlug}`}
+								download
+								className="text-base-content/60 hover:text-base-content hover:bg-base-200 flex items-center gap-1 rounded-full px-3.5 py-1.5 text-sm font-medium transition-all lg:gap-1.5 lg:px-5 lg:py-2 lg:text-sm"
+								aria-label="Download calendar"
+							>
+								<CalendarArrowDown className="h-4 w-4 shrink-0" aria-hidden="true" />
+								<span className="hidden sm:inline">Calendar</span>
+							</a>
+						</li>
+					)}
 					<li className="ml-auto">
 						<Link
 							href="/football/teams"


### PR DESCRIPTION
## Summary

- Adds a `/api/calendar/[slug]` route that generates a `.ics` iCalendar file for any team's fixture schedule
- Adds a **Calendar** download button (with icon) to the team nav, visible when a team has fixtures
- Completed matches marked `CONFIRMED`, upcoming matches `TENTATIVE`
- Each event includes match title, location, and Google Maps link (where coordinates are available)
- Unique, stable UIDs per fixture so re-downloads update rather than duplicate calendar events

## Test plan

- [ ] Visit a team page with fixtures (e.g. `/football/teams/under-12-girls/matches`)
- [ ] Confirm "Calendar" button appears in the nav after the Table tab
- [ ] Click download → `.ics` file saves
- [ ] Open in Apple Calendar or import to Google Calendar → events appear with correct title, time, location
- [ ] Visit `/api/calendar/nonexistent-slug` → 404
- [ ] Visit a team without fixtures → Calendar button absent from nav

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Teams can now download their fixtures as an iCalendar file compatible with calendar applications.
  * A calendar download link is available in the team navigation when fixtures exist.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->