### PR TITLE
chore: block pnpm 11.12.0 and typescript 7 in renovate

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -6,6 +6,11 @@
 			"description": "pnpm 11.12.0 breaks pnpm/action-setup self-install (createFullPkgId integrity crash). See pnpm/action-setup#276. Unblock once pnpm ships a fix.",
 			"matchPackageNames": ["pnpm"],
 			"allowedVersions": "<11.12.0"
+		},
+		{
+			"description": "TypeScript 7 is the native (Go) compiler and ships platform binaries instead of the JS module Next.js loads, so next build fails to detect TypeScript. Unblock once Next.js supports the native compiler.",
+			"matchPackageNames": ["typescript"],
+			"allowedVersions": "<7.0.0"
 		}
 	]
 }

--- a/renovate.json
+++ b/renovate.json
@@ -1,4 +1,11 @@
 {
 	"$schema": "https://docs.renovatebot.com/renovate-schema.json",
-	"extends": ["github>dejanvasic85/renovate-config:nextjs"]
+	"extends": ["github>dejanvasic85/renovate-config:nextjs"],
+	"packageRules": [
+		{
+			"description": "pnpm 11.12.0 breaks pnpm/action-setup self-install (createFullPkgId integrity crash). See pnpm/action-setup#276. Unblock once pnpm ships a fix.",
+			"matchPackageNames": ["pnpm"],
+			"allowedVersions": "<11.12.0"
+		}
+	]
 }


### PR DESCRIPTION
Pins two dependencies in Renovate that currently break the build/CI, so their upgrade PRs stop being re-raised. Remove each rule once upstream support lands.

## pnpm `<11.12.0` (was #730)
pnpm 11.12.0 crashes `pnpm/action-setup` during self-install:
`Cannot use 'in' operator to search for 'integrity' in undefined` (`createFullPkgId`). Confirmed upstream bug — [pnpm/action-setup#276](https://github.com/pnpm/action-setup/issues/276). `standalone: true` doesn't help (exits 127).

## typescript `<7.0.0` (was #722)
TypeScript 7 is the native (Go) compiler, distributed as platform binaries (`@typescript/typescript-*`) instead of the JS module Next.js loads. `next build` then reports *"trying to use TypeScript but do not have the required package(s) installed"* and fails. Next.js 16.2.x doesn't yet consume the native compiler.

🤖 Generated with [Claude Code](https://claude.com/claude-code)