### PR TITLE
chore: only exclude broken pnpm 11.12.0, allow later versions

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -3,9 +3,9 @@
 	"extends": ["github>dejanvasic85/renovate-config:nextjs"],
 	"packageRules": [
 		{
-			"description": "pnpm 11.12.0 breaks pnpm/action-setup self-install (createFullPkgId integrity crash). See pnpm/action-setup#276. Unblock once pnpm ships a fix.",
+			"description": "pnpm 11.12.0 breaks pnpm/action-setup self-install (createFullPkgId integrity crash). See pnpm/action-setup#276. Only this version is excluded; later releases are allowed.",
 			"matchPackageNames": ["pnpm"],
-			"allowedVersions": "<11.12.0"
+			"allowedVersions": "!=11.12.0"
 		},
 		{
 			"description": "TypeScript 7 is the native (Go) compiler and ships platform binaries instead of the JS module Next.js loads, so next build fails to detect TypeScript. Unblock once Next.js supports the native compiler.",


### PR DESCRIPTION
Follow-up to #731. That PR pinned pnpm to `<11.12.0`, which was too aggressive — it would also block 11.13.0+ that fix the [pnpm/action-setup#276](https://github.com/pnpm/action-setup/issues/276) self-install crash.

Narrows the rule to `!=11.12.0` so only the broken release is skipped and later pnpm versions are still picked up automatically.

(The TypeScript `<7.0.0` rule is left as-is — the whole v7 line is the native compiler Next.js can't consume yet, so the full major should stay blocked.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)