### PR TITLE
fix: renovate version pinning

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,16 +1,4 @@
 {
 	"$schema": "https://docs.renovatebot.com/renovate-schema.json",
-	"extends": ["github>dejanvasic85/renovate-config:nextjs"],
-	"packageRules": [
-		{
-			"description": "pnpm 11.12.0 breaks pnpm/action-setup self-install (createFullPkgId integrity crash). See pnpm/action-setup#276. Only this version is excluded; later releases are allowed.",
-			"matchPackageNames": ["pnpm"],
-			"allowedVersions": "!=11.12.0"
-		},
-		{
-			"description": "TypeScript 7 is the native (Go) compiler and ships platform binaries instead of the JS module Next.js loads, so next build fails to detect TypeScript. Unblock once Next.js supports the native compiler.",
-			"matchPackageNames": ["typescript"],
-			"allowedVersions": "<7.0.0"
-		}
-	]
+	"extends": ["github>dejanvasic85/renovate-config:nextjs"]
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Simplified automated dependency update configuration by adopting the shared Next.js preset.
  * Removed custom version restrictions for pnpm and TypeScript.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->