### PR TITLE
fix: preserve asset _id in RSS feed image query to prevent feed 500s

### DIFF
--- a/src/lib/content/news.ts
+++ b/src/lib/content/news.ts
@@ -164,6 +164,7 @@ type FeedArticleQueryResult = Omit<NewsArticle, 'featuredImage'> & {
 	featuredImage?: {
 		alt?: string;
 		asset?: {
+			_id?: string;
 			extension?: string;
 			mimeType?: string;
 		};
@@ -180,6 +181,7 @@ export async function getAllArticlesForFeed() {
 		featuredImage {
 			...,
 			asset-> {
+				_id,
 				extension,
 				mimeType
 			}


### PR DESCRIPTION
## Summary

Fixes a bug where `/feed.xml` (the site's RSS feed) returns a 500 error for any request where an article in the feed has a featured image.

## Root Cause

`getAllArticlesForFeed()` in `src/lib/content/news.ts` runs a GROQ query that dereferences the featured image's asset to pull `extension`/`mimeType`:

```groq
featuredImage {
  ...,
  asset-> {
    extension,
    mimeType
  }
}
```

In GROQ, an explicit projection field (`asset-> {...}`) overrides the same key spread in from `...`, so the result's `featuredImage.asset` ends up as `{ extension, mimeType }` — it no longer carries `_ref` or `_id`.

`urlFor()` (from `@sanity/image-url`) resolves the asset id via `asset._ref || asset._id || ''`. With both missing, it falls back to `''` and `parseAssetId('')` throws:

```
Error: Malformed asset _ref ''. Expected an id like "image-Tb9Ew8CXIwaY6R1kjMvI0uRR-2000x3000-jpg".
```

This is caught by the route handler's try/catch, which logs to Sentry and returns a 500 for the *entire* feed — so any article with a featured image breaks the RSS feed for all subscribers. This matches the 59 recorded occurrences on [WILLIAMSTOWN-SC-G](https://vasic-org.sentry.io/issues/WILLIAMSTOWN-SC-G).

## Fix

Add `_id` to the `asset->` projection. Sanity asset document `_id`s use the same encoded format (`image-<hash>-<width>x<height>-<format>`) that `urlFor()`/`parseAssetId()` expect, so this lets `urlFor()` fall back to `asset._id` and resolve the CDN URL correctly, while still keeping `extension`/`mimeType` for the RSS `<enclosure>` tag.

```diff
 featuredImage {
   ...,
   asset-> {
+    _id,
     extension,
     mimeType
   }
 }
```

## Test Plan

- [x] `pnpm run format` — no changes needed
- [x] `pnpm run lint` — clean
- [x] `pnpm run test` (vitest) — 16 passed
- [x] `pnpm run type:check` — no new errors introduced (confirmed `news.ts` only shows the pre-existing "Cannot find module '@/sanity/sanity.types'" error, which is present repo-wide in this sandbox because it lacks live Sanity credentials to regenerate types — CI pulls real env vars from Vercel and will run this cleanly)
- [ ] `pnpm run build` — could not run locally in this environment (same missing-credentials limitation as above); CI will build with real Sanity/Vercel env vars
- Manual: not verified against a live `/feed.xml` request in this environment (no Sanity credentials available) — recommend confirming the deployed preview's `/feed.xml` returns 200 with an article that has a featured image

## Related

Sentry issue: https://vasic-org.sentry.io/issues/WILLIAMSTOWN-SC-G

---

🤖 Automated fix generated by a scheduled Sentry-triage session.


---
_Generated by [Claude Code](https://claude.ai/code/session_013z6oDDs8rWogYsDyMSdSBf)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved feed image asset handling by including asset identifiers in retrieved content.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->