### PR TITLE
ci: replace wait-for-vercel-preview action with vercel/wait-for-deployment-action

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -61,6 +61,10 @@ jobs:
     timeout-minutes: 20
     needs: [changes, test]
     if: ${{ needs.changes.outputs.app == 'true' }}
+    permissions:
+      contents: read
+      deployments: read
+      statuses: read
     steps:
       - uses: actions/checkout@v7
       - uses: pnpm/action-setup@v6
@@ -76,17 +80,15 @@ jobs:
         run: pnpm exec playwright install --with-deps chromium
       - name: Pull environment variables from Vercel
         run: pnpm dlx vercel env pull .env.local --token=${{ secrets.VERCEL_TOKEN }} --yes
-      - name: Wait for Vercel preview deployment
-        uses: patrickedqvist/wait-for-vercel-preview@v1.3.3
+      - name: Wait for Vercel deployment
+        uses: vercel/wait-for-deployment-action@0e2b0c5c5cce31f1648108aeec56467187aca037
         id: wait_for_vercel
         with:
-          token: ${{ secrets.GITHUB_TOKEN }}
-          max_timeout: 300
-          check_interval: 10
+          environment: ${{ github.ref == 'refs/heads/main' && 'production' || 'preview' }}
       - name: Run E2E tests
         run: pnpm run test:e2e
         env:
-          PLAYWRIGHT_TEST_BASE_URL: ${{ steps.wait_for_vercel.outputs.url }}
+          PLAYWRIGHT_TEST_BASE_URL: ${{ steps.wait_for_vercel.outputs.deployment-url }}
       - name: Upload test results
         uses: actions/upload-artifact@v7
         if: failure()


### PR DESCRIPTION
## Summary
- Replace unmaintained `patrickedqvist/wait-for-vercel-preview` with Vercel's official `vercel/wait-for-deployment-action`, pinned to its latest commit (no tagged releases exist yet)
- Add the job-level `permissions` (`contents: read`, `deployments: read`, `statuses: read`) the new action needs to poll GitHub's Deployments API
- Auth now uses the default `GITHUB_TOKEN` implicitly (no `token` input needed) instead of the previous explicit token/timeout/interval inputs
- Set `environment` to `production` on pushes to `main` and `preview` otherwise, matching Vercel's GitHub integration naming
- Update the output reference from `steps.wait_for_vercel.outputs.url` to `.outputs.deployment-url`

## Test plan
- [x] `pnpm run format`
- [x] `pnpm run lint`
- [x] `pnpm run type:check`
- [x] `pnpm run build`
- [ ] `pnpm run test:e2e` — not run locally; this change only affects the CI wait-for-deployment step, which requires an actual Vercel deployment to verify. Will confirm via the E2E job on this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015V4CaoFQEme2YmZJp9bjMH

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved end-to-end testing against deployed environments.
  * Tests now correctly target production deployments from the main branch and preview deployments from other branches.
  * Enhanced deployment status handling and repository access for more reliable test execution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->