### PR TITLE
feat: matchday SDK client + env config

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -46,6 +46,16 @@ ENV=local
 # Override pino log level (debug, info, warn, error). Defaults to 'debug' in dev, 'info' in production.
 LOG_LEVEL=info
 
+# Matchday API (Server-only)
+# Bearer token + base URL for the matchday SDK client (src/lib/matchday/matchdayClient.ts)
+MATCHDAY_API_TOKEN=your-matchday-api-token
+MATCHDAY_API_BASE_URL=https://api.matchday.example
+
+# Matchday SDK install (NOT read by the app — only needed at `pnpm install` time)
+# read:packages PAT for GitHub Packages, referenced by .npmrc. Export it in your shell
+# (or a personal ~/.npmrc) before running pnpm install/add — .env.local is not read at install time.
+MATCHDAY_SDK_TOKEN=your-github-read-packages-token
+
 # Sentry Error Tracking
 NEXT_PUBLIC_SENTRY_DSN=your-dsn
 SENTRY_AUTH_TOKEN=your-auth-token

--- a/.env.example
+++ b/.env.example
@@ -52,8 +52,11 @@ MATCHDAY_API_TOKEN=your-matchday-api-token
 MATCHDAY_API_BASE_URL=https://api.matchday.example
 
 # Matchday SDK install (NOT read by the app — only needed at `pnpm install` time)
-# read:packages PAT for GitHub Packages, referenced by .npmrc. Export it in your shell
-# (or a personal ~/.npmrc) before running pnpm install/add — .env.local is not read at install time.
+# read:packages PAT for GitHub Packages. There's no project .npmrc (pnpm won't expand
+# env vars in a committed one anyway — supply-chain protection), so configure your own
+# user-level pnpm config once, not here or .env.local:
+#   pnpm config set "@dejanvasic85:registry" "https://npm.pkg.github.com"
+#   pnpm config set "//npm.pkg.github.com/:_authToken" <token>
 MATCHDAY_SDK_TOKEN=your-github-read-packages-token
 
 # Sentry Error Tracking

--- a/.github/actions/pnpm-install/action.yml
+++ b/.github/actions/pnpm-install/action.yml
@@ -1,0 +1,19 @@
+name: pnpm install
+description: Configures GitHub Packages auth for @dejanvasic85 and runs pnpm install --frozen-lockfile
+
+inputs:
+  matchday-sdk-token:
+    description: read:packages token for the @dejanvasic85 GitHub Packages registry
+    required: true
+
+runs:
+  using: composite
+  steps:
+    - name: Configure GitHub Packages auth
+      shell: bash
+      run: |
+        pnpm config set "@dejanvasic85:registry" "https://npm.pkg.github.com"
+        pnpm config set "//npm.pkg.github.com/:_authToken" "${{ inputs.matchday-sdk-token }}"
+    - name: Install dependencies
+      shell: bash
+      run: pnpm install --frozen-lockfile

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,10 +40,12 @@ jobs:
         with:
           node-version-file: '.nvmrc'
           cache: 'pnpm'
+      - name: Configure GitHub Packages auth
+        run: |
+          pnpm config set "@dejanvasic85:registry" "https://npm.pkg.github.com"
+          pnpm config set "//npm.pkg.github.com/:_authToken" "${{ secrets.MATCHDAY_SDK_TOKEN }}"
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
-        env:
-          MATCHDAY_SDK_TOKEN: ${{ secrets.MATCHDAY_SDK_TOKEN }}
       - name: Pull environment variables from Vercel
         run: pnpm dlx vercel env pull .env.local --token=${{ secrets.VERCEL_TOKEN }} --yes
       - name: Build
@@ -76,10 +78,12 @@ jobs:
         with:
           node-version-file: '.nvmrc'
           cache: 'pnpm'
+      - name: Configure GitHub Packages auth
+        run: |
+          pnpm config set "@dejanvasic85:registry" "https://npm.pkg.github.com"
+          pnpm config set "//npm.pkg.github.com/:_authToken" "${{ secrets.MATCHDAY_SDK_TOKEN }}"
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
-        env:
-          MATCHDAY_SDK_TOKEN: ${{ secrets.MATCHDAY_SDK_TOKEN }}
       - name: Install Playwright browsers
         run: pnpm exec playwright install --with-deps chromium
       - name: Pull environment variables from Vercel

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,6 +42,8 @@ jobs:
           cache: 'pnpm'
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
+        env:
+          MATCHDAY_SDK_TOKEN: ${{ secrets.MATCHDAY_SDK_TOKEN }}
       - name: Pull environment variables from Vercel
         run: pnpm dlx vercel env pull .env.local --token=${{ secrets.VERCEL_TOKEN }} --yes
       - name: Build
@@ -76,6 +78,8 @@ jobs:
           cache: 'pnpm'
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
+        env:
+          MATCHDAY_SDK_TOKEN: ${{ secrets.MATCHDAY_SDK_TOKEN }}
       - name: Install Playwright browsers
         run: pnpm exec playwright install --with-deps chromium
       - name: Pull environment variables from Vercel

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,12 +40,9 @@ jobs:
         with:
           node-version-file: '.nvmrc'
           cache: 'pnpm'
-      - name: Configure GitHub Packages auth
-        run: |
-          pnpm config set "@dejanvasic85:registry" "https://npm.pkg.github.com"
-          pnpm config set "//npm.pkg.github.com/:_authToken" "${{ secrets.MATCHDAY_SDK_TOKEN }}"
-      - name: Install dependencies
-        run: pnpm install --frozen-lockfile
+      - uses: ./.github/actions/pnpm-install
+        with:
+          matchday-sdk-token: ${{ secrets.MATCHDAY_SDK_TOKEN }}
       - name: Pull environment variables from Vercel
         run: pnpm dlx vercel env pull .env.local --token=${{ secrets.VERCEL_TOKEN }} --yes
       - name: Build
@@ -78,12 +75,9 @@ jobs:
         with:
           node-version-file: '.nvmrc'
           cache: 'pnpm'
-      - name: Configure GitHub Packages auth
-        run: |
-          pnpm config set "@dejanvasic85:registry" "https://npm.pkg.github.com"
-          pnpm config set "//npm.pkg.github.com/:_authToken" "${{ secrets.MATCHDAY_SDK_TOKEN }}"
-      - name: Install dependencies
-        run: pnpm install --frozen-lockfile
+      - uses: ./.github/actions/pnpm-install
+        with:
+          matchday-sdk-token: ${{ secrets.MATCHDAY_SDK_TOKEN }}
       - name: Install Playwright browsers
         run: pnpm exec playwright install --with-deps chromium
       - name: Pull environment variables from Vercel

--- a/.github/workflows/crawl.yml
+++ b/.github/workflows/crawl.yml
@@ -35,12 +35,9 @@ jobs:
         with:
           node-version-file: '.nvmrc'
           cache: 'pnpm'
-      - name: Configure GitHub Packages auth
-        run: |
-          pnpm config set "@dejanvasic85:registry" "https://npm.pkg.github.com"
-          pnpm config set "//npm.pkg.github.com/:_authToken" "${{ secrets.MATCHDAY_SDK_TOKEN }}"
-      - name: Install dependencies
-        run: pnpm install --frozen-lockfile
+      - uses: ./.github/actions/pnpm-install
+        with:
+          matchday-sdk-token: ${{ secrets.MATCHDAY_SDK_TOKEN }}
       - id: chunk
         name: Compute chunks
         run: |
@@ -60,12 +57,9 @@ jobs:
         with:
           node-version-file: '.nvmrc'
           cache: 'pnpm'
-      - name: Configure GitHub Packages auth
-        run: |
-          pnpm config set "@dejanvasic85:registry" "https://npm.pkg.github.com"
-          pnpm config set "//npm.pkg.github.com/:_authToken" "${{ secrets.MATCHDAY_SDK_TOKEN }}"
-      - name: Install dependencies
-        run: pnpm install --frozen-lockfile
+      - uses: ./.github/actions/pnpm-install
+        with:
+          matchday-sdk-token: ${{ secrets.MATCHDAY_SDK_TOKEN }}
       - name: Cache Playwright browsers
         uses: actions/cache@v6
         with:
@@ -100,12 +94,9 @@ jobs:
         with:
           node-version-file: '.nvmrc'
           cache: 'pnpm'
-      - name: Configure GitHub Packages auth
-        run: |
-          pnpm config set "@dejanvasic85:registry" "https://npm.pkg.github.com"
-          pnpm config set "//npm.pkg.github.com/:_authToken" "${{ secrets.MATCHDAY_SDK_TOKEN }}"
-      - name: Install dependencies
-        run: pnpm install --frozen-lockfile
+      - uses: ./.github/actions/pnpm-install
+        with:
+          matchday-sdk-token: ${{ secrets.MATCHDAY_SDK_TOKEN }}
       - name: Cache Playwright browsers
         uses: actions/cache@v6
         with:
@@ -161,12 +152,9 @@ jobs:
         with:
           node-version-file: '.nvmrc'
           cache: 'pnpm'
-      - name: Configure GitHub Packages auth
-        run: |
-          pnpm config set "@dejanvasic85:registry" "https://npm.pkg.github.com"
-          pnpm config set "//npm.pkg.github.com/:_authToken" "${{ secrets.MATCHDAY_SDK_TOKEN }}"
-      - name: Install dependencies
-        run: pnpm install --frozen-lockfile
+      - uses: ./.github/actions/pnpm-install
+        with:
+          matchday-sdk-token: ${{ secrets.MATCHDAY_SDK_TOKEN }}
       - uses: actions/download-artifact@v8
         with:
           pattern: clubs-data

--- a/.github/workflows/crawl.yml
+++ b/.github/workflows/crawl.yml
@@ -37,6 +37,8 @@ jobs:
           cache: 'pnpm'
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
+        env:
+          MATCHDAY_SDK_TOKEN: ${{ secrets.MATCHDAY_SDK_TOKEN }}
       - id: chunk
         name: Compute chunks
         run: |
@@ -58,6 +60,8 @@ jobs:
           cache: 'pnpm'
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
+        env:
+          MATCHDAY_SDK_TOKEN: ${{ secrets.MATCHDAY_SDK_TOKEN }}
       - name: Cache Playwright browsers
         uses: actions/cache@v6
         with:
@@ -94,6 +98,8 @@ jobs:
           cache: 'pnpm'
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
+        env:
+          MATCHDAY_SDK_TOKEN: ${{ secrets.MATCHDAY_SDK_TOKEN }}
       - name: Cache Playwright browsers
         uses: actions/cache@v6
         with:
@@ -151,6 +157,8 @@ jobs:
           cache: 'pnpm'
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
+        env:
+          MATCHDAY_SDK_TOKEN: ${{ secrets.MATCHDAY_SDK_TOKEN }}
       - uses: actions/download-artifact@v8
         with:
           pattern: clubs-data

--- a/.github/workflows/crawl.yml
+++ b/.github/workflows/crawl.yml
@@ -35,10 +35,12 @@ jobs:
         with:
           node-version-file: '.nvmrc'
           cache: 'pnpm'
+      - name: Configure GitHub Packages auth
+        run: |
+          pnpm config set "@dejanvasic85:registry" "https://npm.pkg.github.com"
+          pnpm config set "//npm.pkg.github.com/:_authToken" "${{ secrets.MATCHDAY_SDK_TOKEN }}"
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
-        env:
-          MATCHDAY_SDK_TOKEN: ${{ secrets.MATCHDAY_SDK_TOKEN }}
       - id: chunk
         name: Compute chunks
         run: |
@@ -58,10 +60,12 @@ jobs:
         with:
           node-version-file: '.nvmrc'
           cache: 'pnpm'
+      - name: Configure GitHub Packages auth
+        run: |
+          pnpm config set "@dejanvasic85:registry" "https://npm.pkg.github.com"
+          pnpm config set "//npm.pkg.github.com/:_authToken" "${{ secrets.MATCHDAY_SDK_TOKEN }}"
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
-        env:
-          MATCHDAY_SDK_TOKEN: ${{ secrets.MATCHDAY_SDK_TOKEN }}
       - name: Cache Playwright browsers
         uses: actions/cache@v6
         with:
@@ -96,10 +100,12 @@ jobs:
         with:
           node-version-file: '.nvmrc'
           cache: 'pnpm'
+      - name: Configure GitHub Packages auth
+        run: |
+          pnpm config set "@dejanvasic85:registry" "https://npm.pkg.github.com"
+          pnpm config set "//npm.pkg.github.com/:_authToken" "${{ secrets.MATCHDAY_SDK_TOKEN }}"
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
-        env:
-          MATCHDAY_SDK_TOKEN: ${{ secrets.MATCHDAY_SDK_TOKEN }}
       - name: Cache Playwright browsers
         uses: actions/cache@v6
         with:
@@ -155,10 +161,12 @@ jobs:
         with:
           node-version-file: '.nvmrc'
           cache: 'pnpm'
+      - name: Configure GitHub Packages auth
+        run: |
+          pnpm config set "@dejanvasic85:registry" "https://npm.pkg.github.com"
+          pnpm config set "//npm.pkg.github.com/:_authToken" "${{ secrets.MATCHDAY_SDK_TOKEN }}"
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
-        env:
-          MATCHDAY_SDK_TOKEN: ${{ secrets.MATCHDAY_SDK_TOKEN }}
       - uses: actions/download-artifact@v8
         with:
           pattern: clubs-data

--- a/.github/workflows/deploy-sanity.yml
+++ b/.github/workflows/deploy-sanity.yml
@@ -30,6 +30,8 @@ jobs:
 
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
+        env:
+          MATCHDAY_SDK_TOKEN: ${{ secrets.MATCHDAY_SDK_TOKEN }}
 
       - name: Deploy to Sanity
         run: pnpm run deploy:sanity -- --yes

--- a/.github/workflows/deploy-sanity.yml
+++ b/.github/workflows/deploy-sanity.yml
@@ -28,10 +28,13 @@ jobs:
           node-version-file: '.nvmrc'
           cache: 'pnpm'
 
+      - name: Configure GitHub Packages auth
+        run: |
+          pnpm config set "@dejanvasic85:registry" "https://npm.pkg.github.com"
+          pnpm config set "//npm.pkg.github.com/:_authToken" "${{ secrets.MATCHDAY_SDK_TOKEN }}"
+
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
-        env:
-          MATCHDAY_SDK_TOKEN: ${{ secrets.MATCHDAY_SDK_TOKEN }}
 
       - name: Deploy to Sanity
         run: pnpm run deploy:sanity -- --yes

--- a/.github/workflows/deploy-sanity.yml
+++ b/.github/workflows/deploy-sanity.yml
@@ -28,13 +28,9 @@ jobs:
           node-version-file: '.nvmrc'
           cache: 'pnpm'
 
-      - name: Configure GitHub Packages auth
-        run: |
-          pnpm config set "@dejanvasic85:registry" "https://npm.pkg.github.com"
-          pnpm config set "//npm.pkg.github.com/:_authToken" "${{ secrets.MATCHDAY_SDK_TOKEN }}"
-
-      - name: Install dependencies
-        run: pnpm install --frozen-lockfile
+      - uses: ./.github/actions/pnpm-install
+        with:
+          matchday-sdk-token: ${{ secrets.MATCHDAY_SDK_TOKEN }}
 
       - name: Deploy to Sanity
         run: pnpm run deploy:sanity -- --yes

--- a/.npmrc
+++ b/.npmrc
@@ -1,2 +1,0 @@
-@dejanvasic85:registry=https://npm.pkg.github.com
-//npm.pkg.github.com/:_authToken=${MATCHDAY_SDK_TOKEN}

--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,2 @@
+@dejanvasic85:registry=https://npm.pkg.github.com
+//npm.pkg.github.com/:_authToken=${MATCHDAY_SDK_TOKEN}

--- a/docs/plans/2026-08-13-matchday-sdk-client-setup.md
+++ b/docs/plans/2026-08-13-matchday-sdk-client-setup.md
@@ -1,0 +1,46 @@
+# Matchday SDK: Env Config + API Client Wrapper
+
+**Created:** 2026-08-13
+**Status:** In Progress
+
+## Purpose
+
+First step of the matchday migration (williamstownsc#821, part of the sequence #821 → #814 → #815 → #816 → #817 → #818 → #819 → #820). Get `@dejanvasic85/matchday-sdk` installed, configured, and callable behind a single client wrapper — no callers wired up yet, that's #818.
+
+## Requirements
+
+- New env vars validated through the existing zod config pattern (`src/lib/config.ts`), not ad-hoc `process.env` reads
+- SDK install works both locally and in every CI workflow that runs `pnpm install`
+- `matchdayClient` importable and typed, following the "services, not utils" convention (AGENTS.md)
+- Out of scope: calling any endpoint, wiring into `matchService`/`tableService`/`clubService` (#818)
+- Blocked on: the deployed matchday API base URL. Not yet known — matchday hosts its API on Cloudflare Workers (their ADR 0009) but no URL has been shared. Confirm before setting `MATCHDAY_API_BASE_URL` in real environments; plan/implementation can proceed with a placeholder in `.env.example`.
+
+## Todo
+
+- [x] Add `matchdayConfigSchema` + `getMatchdayConfig()` to `src/lib/config.ts`
+- [x] Add `MATCHDAY_API_TOKEN` and `MATCHDAY_API_BASE_URL` to `.env.example`
+- [x] Add root `.npmrc` (committed, no secret inline)
+- [x] `MATCHDAY_SDK_TOKEN` set up in a personal `~/.npmrc` locally and as a GitHub Actions repo secret
+- [x] `pnpm add @dejanvasic85/matchday-sdk`
+- [x] New `src/lib/matchday/matchdayClient.ts`: module-level singleton wrapping `createMatchdayClient({ baseUrl, apiToken })`
+- [x] Wire `MATCHDAY_SDK_TOKEN` into the `pnpm install --frozen-lockfile` step's env in `.github/workflows/ci.yml` (both `test` and `e2e` jobs), `.github/workflows/deploy-sanity.yml`, and `.github/workflows/crawl.yml`
+- [ ] Run `pnpm run type:check`
+- [ ] Run `pnpm run lint`
+- [ ] Run `pnpm run format`
+- [ ] Run `pnpm run build`
+
+## Files
+
+- `src/lib/config.ts` — `matchdayConfigSchema`, `MatchdayConfig` type, `getMatchdayConfig()`
+- `.env.example` — `MATCHDAY_API_TOKEN`, `MATCHDAY_API_BASE_URL`, `MATCHDAY_SDK_TOKEN`
+- `.npmrc` — new file, scoped registry for `@dejanvasic85`
+- `package.json` / `pnpm-lock.yaml` — new dependency `@dejanvasic85/matchday-sdk`
+- `src/lib/matchday/matchdayClient.ts` — new file, SDK client singleton
+- `.github/workflows/ci.yml` — both jobs' install step gets `MATCHDAY_SDK_TOKEN` in env
+- `.github/workflows/deploy-sanity.yml` — install step gets `MATCHDAY_SDK_TOKEN` in env
+- `.github/workflows/crawl.yml` — all three jobs' install steps get `MATCHDAY_SDK_TOKEN` in env (still standing until #820 removes it; would otherwise break as soon as the SDK becomes a lockfile dependency)
+
+## Unresolved Questions
+
+- **`MATCHDAY_API_BASE_URL` value** — need the actual deployed URL from the matchday side before this is usable outside a placeholder.
+- **Installed SDK version is `0.1.0`** — the `GET /leagues?clubId=` filter referenced for #816 is documented in the source changelog as `0.2.0` but hadn't been published to GitHub Packages as of this install. Re-check before starting #816.

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
 	"dependencies": {
 		"@aws-sdk/client-ses": "3.1108.0",
 		"@date-fns/tz": "1.5.0",
-		"@dejanvasic85/matchday-sdk": "^0.1.0",
+		"@dejanvasic85/matchday-sdk": "0.1.0",
 		"@fontsource/exo": "5.3.0",
 		"@fontsource/outfit": "5.3.0",
 		"@next/third-parties": "16.3.0",

--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
 	"dependencies": {
 		"@aws-sdk/client-ses": "3.1108.0",
 		"@date-fns/tz": "1.5.0",
+		"@dejanvasic85/matchday-sdk": "^0.1.0",
 		"@fontsource/exo": "5.3.0",
 		"@fontsource/outfit": "5.3.0",
 		"@next/third-parties": "16.3.0",

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
 	"dependencies": {
 		"@aws-sdk/client-ses": "3.1108.0",
 		"@date-fns/tz": "1.5.0",
-		"@dejanvasic85/matchday-sdk": "0.1.0",
+		"@dejanvasic85/matchday-sdk": "0.2.0",
 		"@fontsource/exo": "5.3.0",
 		"@fontsource/outfit": "5.3.0",
 		"@next/third-parties": "16.3.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -14,6 +14,9 @@ importers:
       '@date-fns/tz':
         specifier: 1.5.0
         version: 1.5.0
+      '@dejanvasic85/matchday-sdk':
+        specifier: ^0.1.0
+        version: 0.1.0
       '@fontsource/exo':
         specifier: 5.3.0
         version: 5.3.0
@@ -1006,6 +1009,9 @@ packages:
 
   '@date-fns/utc@2.1.1':
     resolution: {integrity: sha512-SlJDfG6RPeEX8wEVv6ZB3kak4MmbtyiI2qX/5zuKdordbrhB/iaJ58GVMZgJ6P1sJaM1gMgENFYYeg1JWrCFrA==}
+
+  '@dejanvasic85/matchday-sdk@0.1.0':
+    resolution: {integrity: sha512-/6l4YdHIVNz+X/s9z8I/PsPDQdpMyZuQYboiDClQxqDbcD7WYfaH7jS28dj8/tIFdxxHN6adjtXHiNQ/OXXkaw==, tarball: https://npm.pkg.github.com/download/@dejanvasic85/matchday-sdk/0.1.0/dd90480081c665b14bf90f39674b070f9b58d7ed}
 
   '@dnd-kit/accessibility@3.1.1':
     resolution: {integrity: sha512-2P+YgaXF+gRsIihwwY1gCsQSYnu9Zyj2py8kY5fFvUM1qm2WA2u639R6YNVfU4GWr+ZM5mqEsfHZZLoRONbemw==}
@@ -5719,6 +5725,12 @@ packages:
     resolution: {integrity: sha512-smsWv2LzFjP03xmvFoJ331ss6h+jixfA4UUV/Bsiyuu4YJPfN+FIQGOIiv4w9/+MoHkfkJ22UIaQWRVFRfH6Vw==}
     engines: {node: '>=20'}
 
+  openapi-fetch@0.17.0:
+    resolution: {integrity: sha512-PsbZR1wAPcG91eEthKhN+Zn92FMHxv+/faECIwjXdxfTODGSGegYv0sc1Olz+HYPvKOuoXfp+0pA2XVt2cI0Ig==}
+
+  openapi-typescript-helpers@0.1.0:
+    resolution: {integrity: sha512-OKTGPthhivLw/fHz6c3OPtg72vi86qaMlqbJuVJ23qOvQ+53uw1n7HdmkJFibloF7QEjDrDkzJiOJuockM/ljw==}
+
   optionator@0.9.4:
     resolution: {integrity: sha512-6IpQ7mKUxRcZNLIObR0hz7lxsapSSIYNZJwXPGeF0mTVqGKFIXj1DQcMoT22S3ROcLyY/rz0PWaWZ9ayWmad9g==}
     engines: {node: '>= 0.8.0'}
@@ -8295,7 +8307,7 @@ snapshots:
   '@codemirror/language@6.12.4':
     dependencies:
       '@codemirror/state': 6.7.1
-      '@codemirror/view': 6.43.6
+      '@codemirror/view': 6.43.8
       '@lezer/common': 1.5.2
       '@lezer/highlight': 1.2.3
       '@lezer/lr': 1.4.10
@@ -8304,7 +8316,7 @@ snapshots:
   '@codemirror/lint@6.9.5':
     dependencies:
       '@codemirror/state': 6.7.1
-      '@codemirror/view': 6.43.6
+      '@codemirror/view': 6.43.8
       crelt: 1.0.6
 
   '@codemirror/search@6.7.1':
@@ -8321,7 +8333,7 @@ snapshots:
     dependencies:
       '@codemirror/language': 6.12.4
       '@codemirror/state': 6.7.1
-      '@codemirror/view': 6.43.6
+      '@codemirror/view': 6.43.8
       '@lezer/highlight': 1.2.3
 
   '@codemirror/view@6.43.6':
@@ -8365,6 +8377,10 @@ snapshots:
   '@date-fns/tz@1.5.0': {}
 
   '@date-fns/utc@2.1.1': {}
+
+  '@dejanvasic85/matchday-sdk@0.1.0':
+    dependencies:
+      openapi-fetch: 0.17.0
 
   '@dnd-kit/accessibility@3.1.1(react@19.2.8)':
     dependencies:
@@ -9947,7 +9963,7 @@ snapshots:
 
   '@sanity/message-protocol@0.23.0':
     dependencies:
-      '@sanity/comlink': 4.0.1
+      '@sanity/comlink': 4.0.3
 
   '@sanity/message-protocol@0.24.0':
     dependencies:
@@ -10143,7 +10159,7 @@ snapshots:
     dependencies:
       '@sanity/bifur-client': 1.0.0
       '@sanity/client': 7.26.2
-      '@sanity/comlink': 4.0.1
+      '@sanity/comlink': 4.0.3
       '@sanity/diff-match-patch': 3.2.0
       '@sanity/diff-patch': 6.0.0
       '@sanity/id-utils': 1.0.0
@@ -10152,7 +10168,7 @@ snapshots:
       '@sanity/message-protocol': 0.23.0
       '@sanity/mutate': 0.18.1(xstate@5.32.5)
       '@sanity/telemetry': 1.1.0(react@19.2.8)
-      '@sanity/types': 6.9.1(@types/react@19.2.18)
+      '@sanity/types': 6.9.2(@types/react@19.2.18)
       groq: 3.88.1-typegen-experimental.0
       groq-js: 1.30.3(supports-color@8.1.1)
       reselect: 5.2.0
@@ -11546,7 +11562,7 @@ snapshots:
       '@codemirror/lint': 6.9.5
       '@codemirror/search': 6.7.1
       '@codemirror/state': 6.7.1
-      '@codemirror/view': 6.43.6
+      '@codemirror/view': 6.43.8
 
   color-convert@2.0.1:
     dependencies:
@@ -13478,6 +13494,12 @@ snapshots:
       is-inside-container: 1.0.0
       powershell-utils: 0.1.0
       wsl-utils: 0.3.1
+
+  openapi-fetch@0.17.0:
+    dependencies:
+      openapi-typescript-helpers: 0.1.0
+
+  openapi-typescript-helpers@0.1.0: {}
 
   optionator@0.9.4:
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -15,8 +15,8 @@ importers:
         specifier: 1.5.0
         version: 1.5.0
       '@dejanvasic85/matchday-sdk':
-        specifier: 0.1.0
-        version: 0.1.0
+        specifier: 0.2.0
+        version: 0.2.0
       '@fontsource/exo':
         specifier: 5.3.0
         version: 5.3.0
@@ -1010,8 +1010,8 @@ packages:
   '@date-fns/utc@2.1.1':
     resolution: {integrity: sha512-SlJDfG6RPeEX8wEVv6ZB3kak4MmbtyiI2qX/5zuKdordbrhB/iaJ58GVMZgJ6P1sJaM1gMgENFYYeg1JWrCFrA==}
 
-  '@dejanvasic85/matchday-sdk@0.1.0':
-    resolution: {integrity: sha512-/6l4YdHIVNz+X/s9z8I/PsPDQdpMyZuQYboiDClQxqDbcD7WYfaH7jS28dj8/tIFdxxHN6adjtXHiNQ/OXXkaw==, tarball: https://npm.pkg.github.com/download/@dejanvasic85/matchday-sdk/0.1.0/dd90480081c665b14bf90f39674b070f9b58d7ed}
+  '@dejanvasic85/matchday-sdk@0.2.0':
+    resolution: {integrity: sha512-AWE44QD9PjbcfN8US1ZQyRa+Mab17u3fZDzM9t/uQNzAGAgxkeB1YzrsFsKUWOVEFxPN+nj7aZlL5ItWHnGg2g==, tarball: https://npm.pkg.github.com/download/@dejanvasic85/matchday-sdk/0.2.0/78a5799955125c1a67f5f6c1e6203173d1384786}
 
   '@dnd-kit/accessibility@3.1.1':
     resolution: {integrity: sha512-2P+YgaXF+gRsIihwwY1gCsQSYnu9Zyj2py8kY5fFvUM1qm2WA2u639R6YNVfU4GWr+ZM5mqEsfHZZLoRONbemw==}
@@ -8378,7 +8378,7 @@ snapshots:
 
   '@date-fns/utc@2.1.1': {}
 
-  '@dejanvasic85/matchday-sdk@0.1.0':
+  '@dejanvasic85/matchday-sdk@0.2.0':
     dependencies:
       openapi-fetch: 0.17.0
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -15,7 +15,7 @@ importers:
         specifier: 1.5.0
         version: 1.5.0
       '@dejanvasic85/matchday-sdk':
-        specifier: ^0.1.0
+        specifier: 0.1.0
         version: 0.1.0
       '@fontsource/exo':
         specifier: 5.3.0

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,6 +1,7 @@
 minimumReleaseAge: 1440
 minimumReleaseAgeExclude:
   - daisyui
+  - '@dejanvasic85/matchday-sdk'
 allowBuilds:
   '@sentry/cli': true
   esbuild: true

--- a/src/lib/config.ts
+++ b/src/lib/config.ts
@@ -46,6 +46,12 @@ const socialPublishConfigSchema = z.object({
 	socialPublishSecret: z.string().min(1, 'Social publish secret is required')
 });
 
+// Server-only matchday API config schema
+const matchdayConfigSchema = z.object({
+	matchdayApiToken: z.string().min(1, 'Matchday API token is required'),
+	matchdayApiBaseUrl: z.string().url('Matchday API base URL is required')
+});
+
 export type ClubConfig = {
 	wscClubDriblId: string;
 	wscClubDriblName: string;
@@ -57,6 +63,7 @@ export type RevalidationConfig = z.infer<typeof revalidationConfigSchema>;
 export type SanityWriteConfig = z.infer<typeof sanityWriteConfigSchema>;
 export type MetaConfig = z.infer<typeof metaConfigSchema>;
 export type SocialPublishConfig = z.infer<typeof socialPublishConfigSchema>;
+export type MatchdayConfig = z.infer<typeof matchdayConfigSchema>;
 
 let cachedClientConfig: ClientConfig | null = null;
 
@@ -166,4 +173,15 @@ export function getSocialPublishConfig(): SocialPublishConfig {
 
 export function getClubConfig(): ClubConfig {
 	return { wscClubDriblId: '6lNbpDpwdx', wscClubDriblName: 'Williamstown' };
+}
+
+/**
+ * Get matchday API config (server-only)
+ * Contains the bearer token and base URL for the matchday SDK client
+ */
+export function getMatchdayConfig(): MatchdayConfig {
+	return matchdayConfigSchema.parse({
+		matchdayApiToken: process.env.MATCHDAY_API_TOKEN,
+		matchdayApiBaseUrl: process.env.MATCHDAY_API_BASE_URL
+	});
 }

--- a/src/lib/matchday/matchdayClient.ts
+++ b/src/lib/matchday/matchdayClient.ts
@@ -1,0 +1,20 @@
+import { createMatchdayClient } from '@dejanvasic85/matchday-sdk';
+import { getMatchdayConfig } from '@/lib/config';
+
+type MatchdayClient = ReturnType<typeof createMatchdayClient>;
+
+let cachedClient: MatchdayClient | null = null;
+
+export function getMatchdayClient(): MatchdayClient {
+	if (cachedClient) {
+		return cachedClient;
+	}
+
+	const { matchdayApiToken, matchdayApiBaseUrl } = getMatchdayConfig();
+	cachedClient = createMatchdayClient({
+		baseUrl: matchdayApiBaseUrl,
+		apiToken: matchdayApiToken
+	});
+
+	return cachedClient;
+}

--- a/vercel.json
+++ b/vercel.json
@@ -1,5 +1,6 @@
 {
 	"$schema": "https://openapi.vercel.sh/vercel.json",
+	"installCommand": "pnpm config set \"@dejanvasic85:registry\" \"https://npm.pkg.github.com\" && pnpm config set \"//npm.pkg.github.com/:_authToken\" \"$MATCHDAY_SDK_TOKEN\" && pnpm install",
 	"buildCommand": "npm run build",
 	"ignoreCommand": "bash bin/vercel-ignore-build.sh",
 	"redirects": [


### PR DESCRIPTION
## Summary
- Closes #821 — first step of the matchday migration (see #814–#820)
- Installs `@dejanvasic85/matchday-sdk` from GitHub Packages
- New `getMatchdayConfig()` in `src/lib/config.ts` (`MATCHDAY_API_TOKEN`, `MATCHDAY_API_BASE_URL`)
- New `src/lib/matchday/matchdayClient.ts` singleton wrapping `createMatchdayClient`
- `.npmrc` for the scoped GitHub Packages registry, CI wired with `MATCHDAY_SDK_TOKEN`
- No callers yet — wiring into `matchService`/`tableService`/`clubService` is #818

## Test plan
- [x] `pnpm run format`
- [x] `pnpm run lint`
- [x] `pnpm run type:check`
- [x] `pnpm run build`
- [ ] `pnpm run test:e2e` (no behavior change, not run locally — CI will cover it)

https://claude.ai/code/session_015V4CaoFQEme2YmZJp9bjMH

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Matchday API integration with secure server-side configuration.
  * Added validation for required API credentials and base URL settings.
  * Added a reusable, cached Matchday client for future API functionality.

* **Chores**
  * Added the Matchday SDK dependency.
  * Configured package authentication and CI workflows for SDK installation.

* **Documentation**
  * Added implementation planning and setup documentation for the Matchday SDK.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->