### PR TITLE
fix: rename MATCHDAY_SDK_TOKEN to MATCHDAY_GITHUB_TOKEN

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -51,13 +51,13 @@ LOG_LEVEL=info
 MATCHDAY_API_TOKEN=your-matchday-api-token
 MATCHDAY_API_BASE_URL=https://api.matchday.example
 
-# Matchday SDK install (NOT read by the app — only needed at `pnpm install` time)
+# GitHub Packages install (NOT read by the app — only needed at `pnpm install` time)
 # read:packages PAT for GitHub Packages. There's no project .npmrc (pnpm won't expand
 # env vars in a committed one anyway — supply-chain protection), so configure your own
 # user-level pnpm config once, not here or .env.local:
 #   pnpm config set "@dejanvasic85:registry" "https://npm.pkg.github.com"
 #   pnpm config set "//npm.pkg.github.com/:_authToken" <token>
-MATCHDAY_SDK_TOKEN=your-github-read-packages-token
+MATCHDAY_GITHUB_TOKEN=your-github-read-packages-token
 
 # Sentry Error Tracking
 NEXT_PUBLIC_SENTRY_DSN=your-dsn

--- a/.github/actions/pnpm-install/action.yml
+++ b/.github/actions/pnpm-install/action.yml
@@ -2,7 +2,7 @@ name: pnpm install
 description: Configures GitHub Packages auth for @dejanvasic85 and runs pnpm install --frozen-lockfile
 
 inputs:
-  matchday-sdk-token:
+  matchday-github-token:
     description: read:packages token for the @dejanvasic85 GitHub Packages registry
     required: true
 
@@ -13,7 +13,7 @@ runs:
       shell: bash
       run: |
         pnpm config set "@dejanvasic85:registry" "https://npm.pkg.github.com"
-        pnpm config set "//npm.pkg.github.com/:_authToken" "${{ inputs.matchday-sdk-token }}"
+        pnpm config set "//npm.pkg.github.com/:_authToken" "${{ inputs.matchday-github-token }}"
     - name: Install dependencies
       shell: bash
       run: pnpm install --frozen-lockfile

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,7 +42,7 @@ jobs:
           cache: 'pnpm'
       - uses: ./.github/actions/pnpm-install
         with:
-          matchday-sdk-token: ${{ secrets.MATCHDAY_SDK_TOKEN }}
+          matchday-github-token: ${{ secrets.MATCHDAY_GITHUB_TOKEN }}
       - name: Pull environment variables from Vercel
         run: pnpm dlx vercel env pull .env.local --token=${{ secrets.VERCEL_TOKEN }} --yes
       - name: Build
@@ -77,7 +77,7 @@ jobs:
           cache: 'pnpm'
       - uses: ./.github/actions/pnpm-install
         with:
-          matchday-sdk-token: ${{ secrets.MATCHDAY_SDK_TOKEN }}
+          matchday-github-token: ${{ secrets.MATCHDAY_GITHUB_TOKEN }}
       - name: Install Playwright browsers
         run: pnpm exec playwright install --with-deps chromium
       - name: Pull environment variables from Vercel

--- a/.github/workflows/crawl.yml
+++ b/.github/workflows/crawl.yml
@@ -37,7 +37,7 @@ jobs:
           cache: 'pnpm'
       - uses: ./.github/actions/pnpm-install
         with:
-          matchday-sdk-token: ${{ secrets.MATCHDAY_SDK_TOKEN }}
+          matchday-github-token: ${{ secrets.MATCHDAY_GITHUB_TOKEN }}
       - id: chunk
         name: Compute chunks
         run: |
@@ -59,7 +59,7 @@ jobs:
           cache: 'pnpm'
       - uses: ./.github/actions/pnpm-install
         with:
-          matchday-sdk-token: ${{ secrets.MATCHDAY_SDK_TOKEN }}
+          matchday-github-token: ${{ secrets.MATCHDAY_GITHUB_TOKEN }}
       - name: Cache Playwright browsers
         uses: actions/cache@v6
         with:
@@ -96,7 +96,7 @@ jobs:
           cache: 'pnpm'
       - uses: ./.github/actions/pnpm-install
         with:
-          matchday-sdk-token: ${{ secrets.MATCHDAY_SDK_TOKEN }}
+          matchday-github-token: ${{ secrets.MATCHDAY_GITHUB_TOKEN }}
       - name: Cache Playwright browsers
         uses: actions/cache@v6
         with:
@@ -154,7 +154,7 @@ jobs:
           cache: 'pnpm'
       - uses: ./.github/actions/pnpm-install
         with:
-          matchday-sdk-token: ${{ secrets.MATCHDAY_SDK_TOKEN }}
+          matchday-github-token: ${{ secrets.MATCHDAY_GITHUB_TOKEN }}
       - uses: actions/download-artifact@v8
         with:
           pattern: clubs-data

--- a/.github/workflows/deploy-sanity.yml
+++ b/.github/workflows/deploy-sanity.yml
@@ -30,7 +30,7 @@ jobs:
 
       - uses: ./.github/actions/pnpm-install
         with:
-          matchday-sdk-token: ${{ secrets.MATCHDAY_SDK_TOKEN }}
+          matchday-github-token: ${{ secrets.MATCHDAY_GITHUB_TOKEN }}
 
       - name: Deploy to Sanity
         run: pnpm run deploy:sanity -- --yes

--- a/vercel.json
+++ b/vercel.json
@@ -1,6 +1,6 @@
 {
 	"$schema": "https://openapi.vercel.sh/vercel.json",
-	"installCommand": "pnpm config set \"@dejanvasic85:registry\" \"https://npm.pkg.github.com\" && pnpm config set \"//npm.pkg.github.com/:_authToken\" \"$MATCHDAY_SDK_TOKEN\" && pnpm install",
+	"installCommand": "pnpm config set \"@dejanvasic85:registry\" \"https://npm.pkg.github.com\" && pnpm config set \"//npm.pkg.github.com/:_authToken\" \"$MATCHDAY_GITHUB_TOKEN\" && pnpm install",
 	"buildCommand": "npm run build",
 	"ignoreCommand": "bash bin/vercel-ignore-build.sh",
 	"redirects": [


### PR DESCRIPTION
## Summary
- Renamed `MATCHDAY_SDK_TOKEN` to `MATCHDAY_GITHUB_TOKEN` for clarity — it's a GitHub Packages `read:packages` PAT used only at `pnpm install` time, easily confused with `MATCHDAY_API_TOKEN` (the app's runtime matchday API secret)
- `GITHUB_` prefix was rejected by GitHub secrets, so settled on `MATCHDAY_GITHUB_TOKEN`
- Updated `vercel.json`, `.env.example`, the `pnpm-install` composite action, and all three GitHub Actions workflows (`ci.yml`, `deploy-sanity.yml`, `crawl.yml`)

## Manual steps required (outside this repo)
- [x] Add GitHub Actions repo secret `MATCHDAY_GITHUB_TOKEN` (same PAT value), then delete `MATCHDAY_SDK_TOKEN`
- [x] Add Vercel project env var `MATCHDAY_GITHUB_TOKEN` (Production + Preview), then delete `MATCHDAY_SDK_TOKEN`

## Test plan
- [x] `pnpm run format`
- [x] `pnpm run lint`
- [x] `pnpm run type:check`
- [x] `pnpm run build`
- [x] `pnpm run test:e2e` — 20/23 pass; 3 pre-existing failures (search modal, carousel) unrelated to this change (config/CI only, no `src/` changes), reproduced independently on this branch

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01A7Ugh6hzUpfDpWCDnK82cc

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Renamed the GitHub Packages authentication variable to `MATCHDAY_GITHUB_TOKEN`.
  * Updated installation and deployment configuration to use the new variable consistently.
  * Clarified setup comments to reference GitHub Packages authentication.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->