### PR TITLE
feat: add matchday leagueId field to team schema

### DIFF
--- a/src/app/api/studio/leagues/route.ts
+++ b/src/app/api/studio/leagues/route.ts
@@ -1,11 +1,39 @@
-import { NextResponse } from 'next/server';
+import { NextRequest, NextResponse } from 'next/server';
 import * as Sentry from '@sentry/nextjs';
 import logger from '@/lib/logger';
 import { getClubLeagueOptions } from '@/lib/matchday/leagueOptionService';
 
 const log = logger.child({ route: '/api/studio/leagues' });
+const studioPathPrefix = '/studio';
 
-export async function GET() {
+/**
+ * Soft guard, not real auth: rejects requests without a same-origin /studio referer to keep
+ * this off casual/scripted hits and spare the matchday API token's quota. A determined caller
+ * can still spoof the header — the data here (league names) isn't sensitive, so that's an
+ * accepted tradeoff (docs/plans/2026-08-15-team-league-picker-design-spike.md).
+ */
+function isFromStudio(request: NextRequest): boolean {
+	const referer = request.headers.get('referer');
+	if (!referer) {
+		return false;
+	}
+
+	try {
+		const refererUrl = new URL(referer);
+		return (
+			refererUrl.origin === request.nextUrl.origin &&
+			refererUrl.pathname.startsWith(studioPathPrefix)
+		);
+	} catch {
+		return false;
+	}
+}
+
+export async function GET(request: NextRequest) {
+	if (!isFromStudio(request)) {
+		return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+	}
+
 	try {
 		const options = await getClubLeagueOptions();
 		return NextResponse.json({ options });

--- a/src/app/api/studio/leagues/route.ts
+++ b/src/app/api/studio/leagues/route.ts
@@ -1,0 +1,25 @@
+import { NextResponse } from 'next/server';
+import * as Sentry from '@sentry/nextjs';
+import logger from '@/lib/logger';
+import { getClubLeagueOptions } from '@/lib/matchday/leagueOptionService';
+
+const log = logger.child({ route: '/api/studio/leagues' });
+
+export async function GET() {
+	try {
+		const options = await getClubLeagueOptions();
+		return NextResponse.json({ options });
+	} catch (error) {
+		Sentry.captureException(error);
+		log.error({ err: error }, 'studio leagues API error');
+
+		const isDev = process.env.NODE_ENV !== 'production';
+		const responseBody: { error: string; details?: string } = { error: 'Failed to load leagues' };
+
+		if (isDev && error instanceof Error) {
+			responseBody.details = error.message;
+		}
+
+		return NextResponse.json(responseBody, { status: 500 });
+	}
+}

--- a/src/app/studio/[[...tool]]/page.tsx
+++ b/src/app/studio/[[...tool]]/page.tsx
@@ -3,23 +3,26 @@
 import { visionTool } from '@sanity/vision';
 import { NextStudio } from 'next-sanity/studio';
 import { structureTool } from 'sanity/structure';
+import { QueryProvider } from '@/lib/providers/QueryProvider';
 import { csvExportPlugin } from '@/sanity/plugins/csvExport';
 import { schemaTypes } from '@/sanity/schema/index';
 import { structure } from '@/sanity/structure';
 
 export default function StudioPage() {
 	return (
-		<NextStudio
-			config={{
-				title: 'Content Studio',
-				projectId: process.env.NEXT_PUBLIC_SANITY_PROJECT_ID!,
-				dataset: process.env.NEXT_PUBLIC_SANITY_DATASET!,
-				basePath: '/studio',
-				plugins: [structureTool({ structure }), visionTool(), csvExportPlugin()],
-				schema: {
-					types: schemaTypes
-				}
-			}}
-		/>
+		<QueryProvider>
+			<NextStudio
+				config={{
+					title: 'Content Studio',
+					projectId: process.env.NEXT_PUBLIC_SANITY_PROJECT_ID!,
+					dataset: process.env.NEXT_PUBLIC_SANITY_DATASET!,
+					basePath: '/studio',
+					plugins: [structureTool({ structure }), visionTool(), csvExportPlugin()],
+					schema: {
+						types: schemaTypes
+					}
+				}}
+			/>
+		</QueryProvider>
 	);
 }

--- a/src/lib/matchday/leagueOptionService.ts
+++ b/src/lib/matchday/leagueOptionService.ts
@@ -1,0 +1,70 @@
+import { getSiteSettings } from '@/lib/content/siteSettings';
+import logger from '@/lib/logger';
+import { getMatchdayClient } from '@/lib/matchday/matchdayClient';
+import type { LeagueOption } from '@/types/matchday';
+
+const log = logger.child({ service: 'leagueOptionService' });
+
+type League = {
+	id: string;
+	name: string;
+	competitionId: string;
+	seasonId: string;
+};
+
+function buildLabel(
+	league: League,
+	competitionNamesById: Map<string, string>,
+	seasonNamesById: Map<string, string>
+): string {
+	const competitionName = competitionNamesById.get(league.competitionId) ?? league.competitionId;
+	const seasonName = seasonNamesById.get(league.seasonId) ?? league.seasonId;
+	return `${league.name} — ${competitionName} (${seasonName})`;
+}
+
+/**
+ * Leagues this site's club plays in, labelled with their competition + season names.
+ * Falls back to the raw competition/season id in the label if either lookup fails, rather
+ * than dropping the league entirely (docs/plans/2026-08-15-team-league-picker-design-spike.md).
+ */
+export async function getClubLeagueOptions(): Promise<LeagueOption[]> {
+	const siteSettings = await getSiteSettings();
+	const clubId = siteSettings?.matchday?.clubId;
+
+	if (!clubId) {
+		log.warn('siteSettings.matchday.clubId is not set — cannot resolve league options');
+		return [];
+	}
+
+	const client = getMatchdayClient();
+	const [leaguesResult, competitionsResult, seasonsResult] = await Promise.all([
+		client.GET('/leagues', { params: { query: { clubId } } }),
+		client.GET('/competitions'),
+		client.GET('/seasons')
+	]);
+
+	if (leaguesResult.error || !leaguesResult.data) {
+		throw new Error('Failed to load leagues from the matchday API');
+	}
+
+	if (competitionsResult.error) {
+		log.warn({ err: competitionsResult.error }, 'Failed to load competitions, using raw ids');
+	}
+	if (seasonsResult.error) {
+		log.warn({ err: seasonsResult.error }, 'Failed to load seasons, using raw ids');
+	}
+
+	const competitionNamesById = new Map(
+		(competitionsResult.data ?? []).map((competition) => [competition.id, competition.name])
+	);
+	const seasonNamesById = new Map(
+		(seasonsResult.data ?? []).map((season) => [season.id, season.name])
+	);
+
+	return leaguesResult.data
+		.map((league) => ({
+			leagueId: league.id,
+			label: buildLabel(league, competitionNamesById, seasonNamesById)
+		}))
+		.sort((a, b) => a.label.localeCompare(b.label));
+}

--- a/src/lib/matchday/leagueOptionService.ts
+++ b/src/lib/matchday/leagueOptionService.ts
@@ -5,6 +5,8 @@ import type { LeagueOption } from '@/types/matchday';
 
 const log = logger.child({ service: 'leagueOptionService' });
 
+const matchdayRequestTimeoutMs = 10_000;
+
 type League = {
 	id: string;
 	name: string;
@@ -37,10 +39,13 @@ export async function getClubLeagueOptions(): Promise<LeagueOption[]> {
 	}
 
 	const client = getMatchdayClient();
+	const signal = AbortSignal.timeout(matchdayRequestTimeoutMs);
+	// No per-id/batch filter exists for /competitions or /seasons (only /{id}), so this fetches
+	// the full catalog rather than N+1 single-id requests — fine at the current catalog size.
 	const [leaguesResult, competitionsResult, seasonsResult] = await Promise.all([
-		client.GET('/leagues', { params: { query: { clubId } } }),
-		client.GET('/competitions'),
-		client.GET('/seasons')
+		client.GET('/leagues', { params: { query: { clubId } }, signal }),
+		client.GET('/competitions', { signal }),
+		client.GET('/seasons', { signal })
 	]);
 
 	if (leaguesResult.error || !leaguesResult.data) {

--- a/src/sanity/components/LeagueIdInput.tsx
+++ b/src/sanity/components/LeagueIdInput.tsx
@@ -1,0 +1,128 @@
+'use client';
+
+import { useCallback, useMemo } from 'react';
+import { Button, Card, Flex, Spinner, Stack, Text } from '@sanity/ui';
+import { Autocomplete } from '@sanity/ui/autocomplete';
+import { useQuery } from '@tanstack/react-query';
+import { set, unset } from 'sanity';
+import type { StringInputProps } from 'sanity';
+import type { LeagueOption } from '@/types/matchday';
+
+type AutocompleteOption = LeagueOption & { value: string };
+
+const leaguesEndpoint = '/api/studio/leagues';
+const leaguesQueryKey = ['studio-leagues'];
+
+async function fetchLeagueOptions(): Promise<LeagueOption[]> {
+	const response = await fetch(leaguesEndpoint);
+	if (!response.ok) {
+		throw new Error(`Request failed with status ${response.status}`);
+	}
+	const body: { options: LeagueOption[] } = await response.json();
+	return body.options;
+}
+
+function toAutocompleteOptions(options: LeagueOption[]): AutocompleteOption[] {
+	return options.map((option) => ({ ...option, value: option.leagueId }));
+}
+
+export function LeagueIdInput(props: StringInputProps) {
+	const { value, onChange } = props;
+	const {
+		data: options = [],
+		isLoading,
+		isError,
+		refetch
+	} = useQuery({ queryKey: leaguesQueryKey, queryFn: fetchLeagueOptions });
+
+	const autocompleteOptions = useMemo(() => toAutocompleteOptions(options), [options]);
+	const selectedOption = useMemo(
+		() => options.find((option) => option.leagueId === value),
+		[options, value]
+	);
+	const isStale = !isLoading && !isError && Boolean(value) && !selectedOption;
+
+	const handleSelect = useCallback((leagueId: string) => onChange(set(leagueId)), [onChange]);
+	const handleClear = useCallback(() => onChange(unset()), [onChange]);
+
+	if (isLoading) {
+		return (
+			<Flex align="center" gap={2} padding={2}>
+				<Spinner muted />
+				<Text muted size={1}>
+					Loading leagues…
+				</Text>
+			</Flex>
+		);
+	}
+
+	if (isError) {
+		return (
+			<Card padding={3} radius={2} tone="critical">
+				<Stack gap={3}>
+					<Text size={1}>Couldn&apos;t load leagues — try again.</Text>
+					{value && (
+						<Text size={1} muted>
+							Current value: {value}
+						</Text>
+					)}
+					<Button text="Retry" mode="ghost" tone="critical" onClick={() => refetch()} />
+				</Stack>
+			</Card>
+		);
+	}
+
+	return (
+		<Stack gap={3}>
+			{isStale && (
+				<Card padding={3} radius={2} tone="caution">
+					<Flex align="center" justify="space-between" gap={3}>
+						<Stack gap={2}>
+							<Text size={1} weight="semibold">
+								Saved league not found in the current list
+							</Text>
+							<Text size={1} muted>
+								{value}
+							</Text>
+						</Stack>
+						<Button text="Clear" mode="ghost" tone="caution" onClick={handleClear} />
+					</Flex>
+				</Card>
+			)}
+
+			{options.length === 0 ? (
+				<Text muted size={1}>
+					No leagues found for this club yet.
+				</Text>
+			) : (
+				<Autocomplete
+					id="matchday-league-id"
+					options={autocompleteOptions}
+					value={isStale ? undefined : value}
+					placeholder="Search leagues…"
+					renderOption={(option: AutocompleteOption) => (
+						<Card as="button" padding={3} radius={2}>
+							<Text size={1}>{option.label}</Text>
+						</Card>
+					)}
+					renderValue={(optionValue: string, option?: AutocompleteOption) =>
+						option?.label ?? optionValue
+					}
+					filterOption={(query: string, option: AutocompleteOption) =>
+						option.label.toLowerCase().includes(query.toLowerCase())
+					}
+					onSelect={handleSelect}
+				/>
+			)}
+
+			{value && !isStale && selectedOption && (
+				<Flex align="center" justify="space-between" gap={3}>
+					<Text size={1} muted>
+						{value}
+					</Text>
+					<Button text="Clear" mode="ghost" onClick={handleClear} />
+				</Flex>
+			)}
+		</Stack>
+	);
+}

--- a/src/sanity/components/LeagueIdInput.tsx
+++ b/src/sanity/components/LeagueIdInput.tsx
@@ -47,12 +47,19 @@ export function LeagueIdInput(props: StringInputProps) {
 
 	if (isLoading) {
 		return (
-			<Flex align="center" gap={2} padding={2}>
-				<Spinner muted />
-				<Text muted size={1}>
-					Loading leagues…
-				</Text>
-			</Flex>
+			<Stack gap={3}>
+				<Flex align="center" gap={2} padding={2}>
+					<Spinner muted />
+					<Text muted size={1}>
+						Loading leagues…
+					</Text>
+				</Flex>
+				{value && (
+					<Text size={1} muted>
+						Current value: {value}
+					</Text>
+				)}
+			</Stack>
 		);
 	}
 

--- a/src/sanity/schema/team.ts
+++ b/src/sanity/schema/team.ts
@@ -1,4 +1,5 @@
 import { defineField, defineType } from 'sanity';
+import { LeagueIdInput } from '@/sanity/components/LeagueIdInput';
 
 export const team = defineType({
 	name: 'team',
@@ -184,6 +185,28 @@ export const team = defineType({
 			title: 'Fixtures URL',
 			type: 'url',
 			description: 'External link to team fixtures page (e.g. Dribl)'
+		}),
+		defineField({
+			name: 'matchday',
+			title: 'Matchday',
+			type: 'object',
+			fields: [
+				defineField({
+					name: 'leagueId',
+					title: 'League',
+					type: 'string',
+					description:
+						'The Matchday league this team is subscribed to. Optional until the team has been backfilled — see docs/plans/2026-08-15-team-league-picker-design-spike.md.',
+					components: { input: LeagueIdInput },
+					validation: (Rule) =>
+						Rule.custom((value) => {
+							if (typeof value !== 'string' || value.length === 0) {
+								return true;
+							}
+							return /^lea_/.test(value) || 'Must be a Matchday league id (lea_...)';
+						})
+				})
+			]
 		}),
 		defineField({
 			name: 'enableFixturesCrawler',

--- a/src/types/matchday.ts
+++ b/src/types/matchday.ts
@@ -1,0 +1,4 @@
+export type LeagueOption = {
+	leagueId: string;
+	label: string;
+};


### PR DESCRIPTION
## Summary
- New optional `matchday.leagueId` field on `team.ts` (staged rollout — no separate enable flag, field presence is the signal)
- Custom Studio picker (`src/sanity/components/LeagueIdInput.tsx`): searchable autocomplete, loading/error/empty states, never silently drops a saved `leagueId` missing from the current list (shows it with an explicit clear action)
- New server-side route `GET /api/studio/leagues` (`src/lib/matchday/leagueOptionService.ts`) that resolves the club's leagues via the matchday SDK and joins in competition/season names — keeps `MATCHDAY_API_TOKEN` and `clubId` derivation server-only, never exposed to the Studio client
- Added `MATCHDAY_API_BASE_URL` to Vercel (Production + Preview) and `.env.local` — it was missing entirely, which would have broken any matchday API usage
- Old `fixturesCrawler` fields (`enableFixturesCrawler`/`competitionName`/`leagueName`) are untouched — they keep driving the unrelated Dribl crawler per the migration contract in the design doc (#816)

Implements the design from #816.

## Scope note
This covers the schema/tooling part of #817. **Backfilling `leagueId` for the ~19-26 existing teams is not done here** — the issue describes it as a Studio task requiring human judgement to map each team to the correct league, not something to script against production content. Tracked as a follow-up.

## Test plan
- [x] `pnpm run format` / `lint` / `type:check` / `build` all pass
- [x] `pnpm run type:gen` — confirmed `matchday.leagueId` appears in generated types
- [x] `curl localhost:3003/api/studio/leagues` against the real matchday API — returns 18 correctly-labelled leagues for Williamstown
- [ ] Studio UI click-through — not done; requires Google-authenticated Sanity login I don't have access to

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01A7Ugh6hzUpfDpWCDnK82cc

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added league options to the Studio with autocomplete, clearing, loading states, and error handling.
  * Added optional Matchday league selection to team records.
  * League choices are labeled, alphabetically sorted, and support fallback IDs when names are unavailable.
  * Added a protected Studio endpoint for retrieving available league options.

* **Bug Fixes**
  * Preserved saved league values when unavailable in the current options.
  * Improved handling of missing configuration and metadata lookup failures.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->