### PR TITLE
fix: sanity studio production crash (ZodError on deployed studio)

### DIFF
--- a/src/sanity/structure.ts
+++ b/src/sanity/structure.ts
@@ -1,7 +1,6 @@
 import { StructureBuilder } from 'sanity/structure';
-import { getClientConfig } from '@/lib/config';
 
-const { sanityApiVersion } = getClientConfig();
+const sanityApiVersion = '2024-01-01';
 
 export const structure = (S: StructureBuilder) =>
 	S.list()


### PR DESCRIPTION
## Summary
- The standalone `williamstownsc.sanity.studio` deployment (built via `sanity deploy`/Vite, separate from the Next.js app) was crashing on load with a `ZodError` for missing `sanityProjectId`/`sanityDataset`.
- Root cause: PR #836 added a top-level `getClientConfig()` call in `src/sanity/structure.ts`, which is imported by both the Next.js embedded studio and `sanity.config.ts` (used for the standalone deploy). `getClientConfig()` reads `NEXT_PUBLIC_*` env vars that Next.js inlines at webpack build time — the Vite-based standalone Studio build has no such vars, so the module threw at load time and the whole page failed to render.
- Fix: replace the `getClientConfig()`-derived `sanityApiVersion` with the same hardcoded default (`2024-01-01`) directly in `structure.ts`, removing its dependency on Next.js-only env vars.

## Test plan
- [x] `pnpm run type:check`
- [x] `pnpm run lint`
- [x] `npx sanity build` with `NEXT_PUBLIC_*` env vars unset — build now succeeds (previously threw ZodError)
- [ ] After merge, redeploy studio (`pnpm run deploy:sanity`) and confirm `williamstownsc.sanity.studio` loads

🤖 Generated with [Claude Code](https://claude.com/claude-code)