### PR TITLE
fix: No QueryClient set error on matchday league picker in Studio

### DIFF
--- a/sanity.config.ts
+++ b/sanity.config.ts
@@ -1,6 +1,7 @@
 import { visionTool } from '@sanity/vision';
 import { defineConfig } from 'sanity';
 import { structureTool } from 'sanity/structure';
+import { StudioLayout } from './src/sanity/components/StudioLayout';
 import { csvExportPlugin } from './src/sanity/plugins/csvExport';
 import { schemaTypes } from './src/sanity/schema/index';
 import { structure } from './src/sanity/structure';
@@ -14,5 +15,10 @@ export default defineConfig({
 	plugins: [structureTool({ structure }), visionTool(), csvExportPlugin()],
 	schema: {
 		types: schemaTypes
+	},
+	studio: {
+		components: {
+			layout: StudioLayout
+		}
 	}
 });

--- a/src/app/studio/[[...tool]]/page.tsx
+++ b/src/app/studio/[[...tool]]/page.tsx
@@ -3,26 +3,29 @@
 import { visionTool } from '@sanity/vision';
 import { NextStudio } from 'next-sanity/studio';
 import { structureTool } from 'sanity/structure';
-import { QueryProvider } from '@/lib/providers/QueryProvider';
+import { StudioLayout } from '@/sanity/components/StudioLayout';
 import { csvExportPlugin } from '@/sanity/plugins/csvExport';
 import { schemaTypes } from '@/sanity/schema/index';
 import { structure } from '@/sanity/structure';
 
 export default function StudioPage() {
 	return (
-		<QueryProvider>
-			<NextStudio
-				config={{
-					title: 'Content Studio',
-					projectId: process.env.NEXT_PUBLIC_SANITY_PROJECT_ID!,
-					dataset: process.env.NEXT_PUBLIC_SANITY_DATASET!,
-					basePath: '/studio',
-					plugins: [structureTool({ structure }), visionTool(), csvExportPlugin()],
-					schema: {
-						types: schemaTypes
+		<NextStudio
+			config={{
+				title: 'Content Studio',
+				projectId: process.env.NEXT_PUBLIC_SANITY_PROJECT_ID!,
+				dataset: process.env.NEXT_PUBLIC_SANITY_DATASET!,
+				basePath: '/studio',
+				plugins: [structureTool({ structure }), visionTool(), csvExportPlugin()],
+				schema: {
+					types: schemaTypes
+				},
+				studio: {
+					components: {
+						layout: StudioLayout
 					}
-				}}
-			/>
-		</QueryProvider>
+				}
+			}}
+		/>
 	);
 }

--- a/src/sanity/components/StudioLayout.tsx
+++ b/src/sanity/components/StudioLayout.tsx
@@ -1,0 +1,21 @@
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import type { LayoutProps } from 'sanity';
+
+const staleTimeMs = 60 * 1000;
+
+const queryClient = new QueryClient({
+	defaultOptions: {
+		queries: {
+			staleTime: staleTimeMs,
+			retry: false
+		}
+	}
+});
+
+export function StudioLayout({ renderDefault, ...props }: LayoutProps) {
+	return (
+		<QueryClientProvider client={queryClient}>
+			{renderDefault({ ...props, renderDefault })}
+		</QueryClientProvider>
+	);
+}


### PR DESCRIPTION
## Summary
- Production Studio (`williamstownsc.sanity.studio`) throws `Error: No QueryClient set, use QueryClientProvider to set one` when opening the League field on a team document.
- `LeagueIdInput` (the custom input component for `matchday.leagueId`) uses `useQuery` from `@tanstack/react-query`, but neither `sanity.config.ts` (used for the standalone Studio deploy) nor the tree it renders into ever wrapped the Studio in a `QueryClientProvider`. The Next.js embedded studio route (`/studio`) happened to wrap `NextStudio` in `QueryProvider`, but that only covers the app-router entry point — not the standalone deployed Studio, which is the one in production.
- Fix: added `src/sanity/components/StudioLayout.tsx`, a Studio `layout` component that wraps the default layout in a `QueryClientProvider`, and registered it via `studio.components.layout` in both `sanity.config.ts` and the Next.js `/studio` page's config. Removed the now-redundant `QueryProvider` wrapper from the Next.js studio page so there's a single source of truth for the Studio's query client.

## Test plan
- [x] `pnpm run type:check`
- [x] `pnpm run lint`
- [x] `pnpm run build` (Next.js) — `/studio/[[...tool]]` compiles
- [x] `npx sanity build` (standalone deploy target) — builds successfully
- [ ] After merge/deploy, open a team document's Matchday League field on `williamstownsc.sanity.studio` and confirm the picker loads without the QueryClient error

🤖 Generated with [Claude Code](https://claude.com/claude-code)