### PR TITLE
fix: cross-origin failure loading leagues in standalone studio

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,3 +1,6 @@
+# Site URL (used by the standalone sanity.studio deploy to call back into this app's API routes)
+NEXT_PUBLIC_SITE_URL=http://localhost:3003
+
 # Sanity CMS Configuration
 NEXT_PUBLIC_SANITY_PROJECT_ID=your-project-id
 NEXT_PUBLIC_SANITY_DATASET=production

--- a/src/app/api/studio/leagues/route.ts
+++ b/src/app/api/studio/leagues/route.ts
@@ -5,38 +5,51 @@ import { getClubLeagueOptions } from '@/lib/matchday/leagueOptionService';
 
 const log = logger.child({ route: '/api/studio/leagues' });
 const studioPathPrefix = '/studio';
+const standaloneStudioOrigin = 'https://williamstownsc.sanity.studio';
 
 /**
- * Soft guard, not real auth: rejects requests without a same-origin /studio referer to keep
- * this off casual/scripted hits and spare the matchday API token's quota. A determined caller
- * can still spoof the header — the data here (league names) isn't sensitive, so that's an
- * accepted tradeoff (docs/plans/2026-08-15-team-league-picker-design-spike.md).
+ * Soft guard, not real auth: rejects requests without a referer from either the
+ * Next.js-embedded studio (same origin, /studio path) or the standalone deployed studio
+ * (williamstownsc.sanity.studio) to keep this off casual/scripted hits and spare the
+ * matchday API token's quota. A determined caller can still spoof the header — the data
+ * here (league names) isn't sensitive, so that's an accepted tradeoff
+ * (docs/plans/2026-08-15-team-league-picker-design-spike.md).
  */
-function isFromStudio(request: NextRequest): boolean {
+function isFromStudio(refererUrl: URL, requestOrigin: string): boolean {
+	const isEmbeddedStudio =
+		refererUrl.origin === requestOrigin && refererUrl.pathname.startsWith(studioPathPrefix);
+	const isStandaloneStudio = refererUrl.origin === standaloneStudioOrigin;
+
+	return isEmbeddedStudio || isStandaloneStudio;
+}
+
+function parseRefererUrl(request: NextRequest): URL | null {
 	const referer = request.headers.get('referer');
 	if (!referer) {
-		return false;
+		return null;
 	}
 
 	try {
-		const refererUrl = new URL(referer);
-		return (
-			refererUrl.origin === request.nextUrl.origin &&
-			refererUrl.pathname.startsWith(studioPathPrefix)
-		);
+		return new URL(referer);
 	} catch {
-		return false;
+		return null;
 	}
 }
 
 export async function GET(request: NextRequest) {
-	if (!isFromStudio(request)) {
+	const refererUrl = parseRefererUrl(request);
+	if (!refererUrl || !isFromStudio(refererUrl, request.nextUrl.origin)) {
 		return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
 	}
 
+	const corsHeaders =
+		refererUrl.origin === standaloneStudioOrigin
+			? { 'Access-Control-Allow-Origin': standaloneStudioOrigin }
+			: undefined;
+
 	try {
 		const options = await getClubLeagueOptions();
-		return NextResponse.json({ options });
+		return NextResponse.json({ options }, { headers: corsHeaders });
 	} catch (error) {
 		Sentry.captureException(error);
 		log.error({ err: error }, 'studio leagues API error');
@@ -48,6 +61,6 @@ export async function GET(request: NextRequest) {
 			responseBody.details = error.message;
 		}
 
-		return NextResponse.json(responseBody, { status: 500 });
+		return NextResponse.json(responseBody, { status: 500, headers: corsHeaders });
 	}
 }

--- a/src/sanity/components/LeagueIdInput.tsx
+++ b/src/sanity/components/LeagueIdInput.tsx
@@ -10,7 +10,9 @@ import type { LeagueOption } from '@/types/matchday';
 
 type AutocompleteOption = LeagueOption & { value: string };
 
-const leaguesEndpoint = '/api/studio/leagues';
+const defaultSiteUrl = 'https://www.williamstownsc.com';
+const siteUrl = process.env.NEXT_PUBLIC_SITE_URL ?? defaultSiteUrl;
+const leaguesEndpoint = `${siteUrl}/api/studio/leagues`;
 const leaguesQueryKey = ['studio-leagues'];
 
 async function fetchLeagueOptions(): Promise<LeagueOption[]> {


### PR DESCRIPTION
## Summary
- The League picker on the production Studio (`williamstownsc.sanity.studio`) failed with `Couldn't load leagues — try again.` The browser console showed the request being redirected to `sanity.io/...` and blocked by CORS with `Access-Control-Allow-Origin: https://admin.sanity.io` — not this app's CORS policy at all.
- Root cause: `LeagueIdInput` called `fetch('/api/studio/leagues')` with a **relative** path. On the standalone `sanity.studio` deployment (a different origin from the Next.js app), that relative path resolves against Sanity's own domain instead of `williamstownsc.com`, so it never reaches the real API route. Even if it had, `isFromStudio()`'s referer guard only accepted same-origin `/studio` referers — it didn't know about the standalone Studio's origin.
- Fix:
  - `LeagueIdInput` now builds an absolute URL using `NEXT_PUBLIC_SITE_URL` (falling back to `https://www.williamstownsc.com`) so it always targets the real API regardless of which Studio origin renders it.
  - `isFromStudio()` in `/api/studio/leagues` now also accepts referers from `https://williamstownsc.sanity.studio`, and the route echoes back a matching `Access-Control-Allow-Origin` header on that path so the browser accepts the cross-origin response (it's a simple GET, so no preflight is triggered).

## Test plan
- [x] `pnpm run type:check`
- [x] `pnpm run lint`
- [x] `pnpm run build` (Next.js) — `/studio/[[...tool]]` and `/api/studio/leagues` compile
- [x] `npx sanity build` (standalone deploy target) — builds successfully
- [ ] After merge/deploy, open a team's Matchday League field on `williamstownsc.sanity.studio` and confirm the league list loads

🤖 Generated with [Claude Code](https://claude.com/claude-code)