### PR TITLE
fix: allow null fixture name from Dribl API

### DIFF
--- a/src/types/matches.ts
+++ b/src/types/matches.ts
@@ -76,7 +76,7 @@ export const clubsSchema = z.object({
 });
 
 const externalFixtureAttributesSchema = z.object({
-	name: z.string(),
+	name: z.string().nullable(),
 	date: z.string(),
 	round: z.string(),
 	full_round: z.string(),


### PR DESCRIPTION
## Summary
- Scheduled crawler workflow (run 32254803193) has been failing for chunk 5 due to a zod validation error on `metros-mens` fixtures.
- Dribl now returns `null` for `attributes.name` on some fixture rows — `externalFixtureAttributesSchema.name` required a string, so the crawl aborted.
- Made `name` nullable, matching sibling fields (`home_team_name`, `away_team_name`) that are already nullable. The field is unused downstream.

## Test plan
- [x] `pnpm run format`
- [x] `pnpm run lint`
- [x] `pnpm run type:check`
- [x] `pnpm run build`
- [x] Re-ran `pnpm exec dotenv -e .env.local -- tsx bin/wsc.ts crawl fixtures --team metros-mens` locally against live Dribl data — crawl now completes successfully (previously threw the same zod error seen in CI).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated external fixture data handling to support cases where the fixture name is unavailable or null.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->