### PR TITLE
Fix: guard localStorage access in Banner against null storage

### DIFF
--- a/src/components/layout/Banner/Banner.tsx
+++ b/src/components/layout/Banner/Banner.tsx
@@ -37,8 +37,24 @@ function subscribeToDismissed(callback: () => void): () => void {
 	return () => window.removeEventListener(dismissedAnnouncementsEvent, callback);
 }
 
+function readDismissedAnnouncements(): string | null {
+	try {
+		return localStorage.getItem(dismissedAnnouncementsKey);
+	} catch {
+		return null;
+	}
+}
+
+function writeDismissedAnnouncements(raw: string): void {
+	try {
+		localStorage.setItem(dismissedAnnouncementsKey, raw);
+	} catch {
+		// storage unavailable (privacy mode, blocked storage, etc.) - dismissal won't persist
+	}
+}
+
 function getDismissedSnapshot(): string[] {
-	const raw = localStorage.getItem(dismissedAnnouncementsKey);
+	const raw = readDismissedAnnouncements();
 	if (raw !== cachedRaw) {
 		cachedRaw = raw;
 		cachedParsed = parseDismissed(raw);
@@ -58,9 +74,9 @@ export const Banner = ({ messages }: BannerProps) => {
 	);
 
 	const handleDismiss = (bannerId: string) => {
-		const current = parseDismissed(localStorage.getItem(dismissedAnnouncementsKey));
+		const current = parseDismissed(readDismissedAnnouncements());
 		const updated = Array.from(new Set([...current, bannerId]));
-		localStorage.setItem(dismissedAnnouncementsKey, JSON.stringify(updated));
+		writeDismissedAnnouncements(JSON.stringify(updated));
 		window.dispatchEvent(new Event(dismissedAnnouncementsEvent));
 	};
 


### PR DESCRIPTION
## Summary

- Sentry issue [WILLIAMSTOWN-SC-10](https://vasic-org.sentry.io/issues/WILLIAMSTOWN-SC-10): `TypeError: Cannot read properties of null (reading 'getItem')` at `src/components/layout/Banner/Banner.tsx:41`.
- Root cause: `getDismissedSnapshot()` and `handleDismiss()` called `localStorage.getItem`/`setItem` directly and unguarded. In some browser contexts (private browsing modes, storage-blocking extensions, locked-down in-app webviews) `window.localStorage` itself is `null` rather than throwing on access, so the direct call crashed the `useSyncExternalStore` snapshot function on render.
- Fix: extracted `readDismissedAnnouncements()` / `writeDismissedAnnouncements()` helpers that wrap the storage calls in `try/catch`, falling back to `null`/no-op when storage is unavailable. Dismissal simply won't persist in that case instead of crashing the banner.

This is a self-contained, low-risk client-side change — no new dependencies, no change to component props or rendered output in the common case.

## Note on automated checks

This PR was opened by an automated Sentry-triage session. Local validation (`pnpm run format` / `lint` / `type:check` / `build`) could not be run in that sandbox because `pnpm install` fails on the private `@dejanvasic85/matchday-sdk` GitHub Packages dependency (401 — no scoped credential available in that environment). This is an environment limitation unrelated to this change. Repo CI has the correct credentials and will run the full check suite on this PR; the session is watching this PR and will address any real CI failures.

## Test plan

- [ ] CI: format, lint, type:check, build all pass
- [ ] Manual: with `localStorage` mocked to `null`/throwing, confirm the Banner renders without crashing and dismiss button is a no-op instead of throwing
- [ ] Manual: normal flow — dismiss a banner, reload, confirm it stays dismissed

Sentry issue: https://vasic-org.sentry.io/issues/WILLIAMSTOWN-SC-10

---
_Generated by [Claude Code](https://claude.ai/code/session_017FJsCau2Km5v2tKss6TfPG)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved announcement dismissal handling when browser storage is unavailable.
  * Ensured dismissed announcements continue to be saved and restored safely without disrupting existing behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->